### PR TITLE
[Feat] 할 일 모달 리팩토링 및 기능 추가 (Zustand, 반복주기 설정 등)

### DIFF
--- a/src/app/(route)/GiBeom/page.tsx
+++ b/src/app/(route)/GiBeom/page.tsx
@@ -2,23 +2,21 @@
 import { useState } from 'react';
 import TodoModal from '@/components/common/Modal/TodoModal';
 import { TodoType } from '@/types/TodoType';
+import { useTodoModalStore } from '@/store/useTodoModalStore';
 
 export default function GiBeom() {
-  const [isOpen, setIsOpen] = useState(true);
-  const [todoType, setTodoType] = useState<TodoType>('생성');
+  const { isOpen, open } = useTodoModalStore();
 
-  const handleClose = () => {
-    setIsOpen(false);
-  };
+  const [todoType, setTodoType] = useState<TodoType>('생성');
 
   const handleOpenTypeAssign = () => {
     setTodoType('생성');
-    setIsOpen(true);
+    open();
   };
 
   const handleOpenTypeModify = () => {
     setTodoType('수정');
-    setIsOpen(true);
+    open();
   };
 
   return (
@@ -29,7 +27,7 @@ export default function GiBeom() {
       <button className="bg-red-700" onClick={handleOpenTypeModify}>
         할일 수정 열어
       </button>
-      {isOpen ? <TodoModal onClose={handleClose} todoType={todoType} /> : <></>}
+      {isOpen ? <TodoModal todoType={todoType} /> : <></>}
     </div>
   );
 }

--- a/src/components/common/Modal/ModalContainer/index.tsx
+++ b/src/components/common/Modal/ModalContainer/index.tsx
@@ -1,15 +1,17 @@
 import { ReactNode } from 'react';
+import { useTodoModalStore } from '@/store/useTodoModalStore';
 
 interface ModalContainerProps {
   children: ReactNode;
-  onClose: () => void;
 }
 
-export const ModalContainer = ({ children, onClose }: ModalContainerProps) => {
+export const ModalContainer = ({ children }: ModalContainerProps) => {
+  const { close } = useTodoModalStore();
+
   const handleBackgroundClick = (e: React.MouseEvent<HTMLDivElement>) => {
     // 배경 클릭 시 onClose 호출
     if (e.target === e.currentTarget) {
-      onClose();
+      close();
     }
   };
   return (

--- a/src/components/common/Modal/TodoModal/TodoModalDocs/LinkUpload/index.tsx
+++ b/src/components/common/Modal/TodoModal/TodoModalDocs/LinkUpload/index.tsx
@@ -12,7 +12,7 @@ export const LinkUpload = () => {
         <input
           type="url"
           placeholder={PLACEHOLDERS.LINK_INPUT}
-          className="mt-4 w-full max-w-[500px] rounded-8 border px-4 py-2 text-sm text-slate-600 focus:outline-none" // 길이 늘림
+          className="mt-4 w-full max-w-500 rounded-8 border px-4 py-2 text-sm text-slate-600 focus:outline-none" // 길이 늘림
         />
       </div>
     </div>

--- a/src/components/common/Modal/TodoModal/TodoModalHeader/index.tsx
+++ b/src/components/common/Modal/TodoModal/TodoModalHeader/index.tsx
@@ -3,10 +3,16 @@ import { IoMdClose } from 'react-icons/io';
 import { FaCheck } from 'react-icons/fa6';
 import { TodoModalProps } from '@/types/TodoType';
 import { useTodoModalStore } from '@/store/useTodoModalStore';
+import { cn } from '@/utils/className';
 
 export const TodoModalHeader = ({ todoType }: TodoModalProps) => {
   const { close } = useTodoModalStore();
   const [isChkClick, setIstChkClick] = useState(false);
+
+  const iconContainerClass = cn(
+    'flex size-18 items-start justify-center rounded-6 border border-slate-200',
+    isChkClick ? 'bg-blue-600' : 'bg-white',
+  );
 
   const handleClose = () => {
     close();
@@ -28,10 +34,7 @@ export const TodoModalHeader = ({ todoType }: TodoModalProps) => {
         <></>
       ) : (
         <div className="flex items-center gap-6">
-          <button
-            className={`flex size-18 items-start justify-center rounded-6 border border-slate-200 ${isChkClick ? 'bg-blue-600' : 'bg-white'} `}
-            onClick={handleClick}
-          >
+          <button className={iconContainerClass} onClick={handleClick}>
             {isChkClick ? <FaCheck className="size-16 text-white" /> : <></>}
           </button>
 

--- a/src/components/common/Modal/TodoModal/TodoModalHeader/index.tsx
+++ b/src/components/common/Modal/TodoModal/TodoModalHeader/index.tsx
@@ -2,12 +2,14 @@ import { useState } from 'react';
 import { IoMdClose } from 'react-icons/io';
 import { FaCheck } from 'react-icons/fa6';
 import { TodoModalProps } from '@/types/TodoType';
+import { useTodoModalStore } from '@/store/useTodoModalStore';
 
-export const TodoModalHeader = ({ onClose, todoType }: TodoModalProps) => {
+export const TodoModalHeader = ({ todoType }: TodoModalProps) => {
+  const { close } = useTodoModalStore();
   const [isChkClick, setIstChkClick] = useState(false);
 
   const handleClose = () => {
-    onClose();
+    close();
   };
 
   const handleClick = () => {

--- a/src/components/common/Modal/TodoModal/TodoModalRepeat/index.tsx
+++ b/src/components/common/Modal/TodoModal/TodoModalRepeat/index.tsx
@@ -1,0 +1,15 @@
+import { PLACEHOLDERS } from '@/constants/Placeholders';
+
+export const TodoModalRepeat = () => {
+  return (
+    <div className="mt-20 flex flex-col items-start gap-12 self-stretch sm:mt-0">
+      <span className="text-base-semibold text-slate-800">반복 설정</span>
+      <div className="flex items-center justify-start self-stretch rounded-12 bg-slate-50 px-20 py-12 text-sm-normal sm:text-base-normal">
+        <input
+          className="bg-slate-50 focus:outline-none"
+          placeholder={PLACEHOLDERS.REPEAT}
+        />
+      </div>
+    </div>
+  );
+};

--- a/src/components/common/Modal/TodoModal/index.tsx
+++ b/src/components/common/Modal/TodoModal/index.tsx
@@ -5,17 +5,19 @@ import { TodoModalDocs } from './TodoModalDocs';
 import { TodoModalHeader } from './TodoModalHeader';
 import { TodoModalTarget } from './TodoModalTarget';
 import { TodoModalTitle } from './TodoModalTitle';
+import { TodoModalRepeat } from './TodoModalRepeat';
 
 const TodoModal = ({ todoType }: TodoModalProps) => {
   return (
     <ModalContainer>
-      <div className="flex size-full flex-col items-start gap-10 bg-white px-16 py-24 sm:h-auto sm:w-520 sm:rounded-12 sm:p-24">
+      <div className="flex size-full flex-col items-start gap-10 overflow-y-auto bg-white px-16 py-24 sm:h-auto sm:w-520 sm:rounded-12 sm:p-24">
         <div className="flex flex-1 flex-col items-start gap-40 self-stretch">
           <div className="flex flex-col gap-24 self-stretch">
             <TodoModalHeader todoType={todoType} />
             <TodoModalTitle />
             <TodoModalDocs />
             <TodoModalTarget />
+            <TodoModalRepeat />
           </div>
           <TodoModalBtn />
         </div>

--- a/src/components/common/Modal/TodoModal/index.tsx
+++ b/src/components/common/Modal/TodoModal/index.tsx
@@ -6,13 +6,13 @@ import { TodoModalHeader } from './TodoModalHeader';
 import { TodoModalTarget } from './TodoModalTarget';
 import { TodoModalTitle } from './TodoModalTitle';
 
-const TodoModal = ({ onClose, todoType }: TodoModalProps) => {
+const TodoModal = ({ todoType }: TodoModalProps) => {
   return (
-    <ModalContainer onClose={onClose}>
+    <ModalContainer>
       <div className="flex size-full flex-col items-start gap-10 bg-white px-16 py-24 sm:h-auto sm:w-520 sm:rounded-12 sm:p-24">
         <div className="flex flex-1 flex-col items-start gap-40 self-stretch">
           <div className="flex flex-col gap-24 self-stretch">
-            <TodoModalHeader onClose={onClose} todoType={todoType} />
+            <TodoModalHeader todoType={todoType} />
             <TodoModalTitle />
             <TodoModalDocs />
             <TodoModalTarget />

--- a/src/constants/Placeholders.ts
+++ b/src/constants/Placeholders.ts
@@ -4,4 +4,5 @@ export const PLACEHOLDERS = {
   FILE: '파일을 업로드해주세요',
   LINK_ATTACH: '링크를 첨부해주세요',
   LINK_INPUT: '링크를 입력하세요',
+  REPEAT: '주 5일',
 };

--- a/src/store/useTodoModalStore.ts
+++ b/src/store/useTodoModalStore.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand';
+
+interface TodoModalState {
+  isOpen: boolean;
+  open: () => void;
+  close: () => void;
+}
+
+export const useTodoModalStore = create<TodoModalState>((set) => ({
+  isOpen: false,
+  open: () => set({ isOpen: true }),
+  close: () => set({ isOpen: false }),
+}));

--- a/src/types/TodoType.ts
+++ b/src/types/TodoType.ts
@@ -1,6 +1,5 @@
 export type TodoType = '생성' | '수정';
 
 export interface TodoModalProps {
-  onClose: () => void;
   todoType: TodoType;
 }


### PR DESCRIPTION
# 📄 할 일 모달 리팩토링 및 기능 추가

## 📝 변경 사항 요약
- [TodoModal 열림 상태 store 생성 및 관리](https://github.com/slid-todo/front/commit/c8a0202ce8b8f507cc0eab039293eaf6af307dbe)
- [반복 설정에 관한 컴포넌트 추가](https://github.com/slid-todo/front/commit/a242009533629c0b84cae5ebbc872a120bd060cb)
- [cn 유틸 함수 사용](https://github.com/slid-todo/front/commit/cfa3cb2f1b8bffa273f401e44e4ad3f9188ffc9c)

## 📌 관련 이슈
- 이슈 번호: #36 

## 🔍 변경 사항 상세 설명
TodoModal 열림 상태를 기본 useState 사용에서 zustand store 사용으로 변경
반복 설정에 관한 input이 누락되어 변경
cn 유틸 함수를 이용하여 아이콘 클릭에 관한 디자인 변경 클래스 생성

## ✅ 확인 사항
- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 관련 테스트를 작성하고 모두 통과했는지 확인했습니다.
- [x] 코드 스타일 가이드에 맞게 작성했습니다.

## 📸 스크린샷 (선택 사항)
이전 PR과 동일

