### PR TITLE
[Feat] create input component

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -11,6 +11,7 @@ const config: StorybookConfig = {
     '@chromatic-com/storybook',
     '@storybook/addon-interactions',
     '@storybook/addon-styling-webpack',
+    '@storybook/addon-backgrounds',
   ],
   framework: {
     name: '@storybook/nextjs',

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "@storybook/addon-backgrounds": "^8.4.5",
     "@tanstack/react-query": "^5.61.0",
     "@tanstack/react-query-devtools": "^5.61.0",
     "axios": "^1.7.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@storybook/addon-backgrounds':
+        specifier: ^8.4.5
+        version: 8.4.5(storybook@8.4.5(prettier@3.3.3))
       '@tanstack/react-query':
         specifier: ^5.61.0
         version: 5.61.3(react@18.2.0)

--- a/src/components/common/Chip/index.tsx
+++ b/src/components/common/Chip/index.tsx
@@ -9,8 +9,8 @@ const chipStyles = {
     active: 'bg-slate-900 !text-white',
   },
   size: {
-    sm: 'text-sm font-medium',
-    lg: 'text-base font-medium',
+    sm: 'text-sm-medium',
+    lg: 'text-base-medium',
   },
 };
 

--- a/src/components/common/Input/index.stories.ts
+++ b/src/components/common/Input/index.stories.ts
@@ -1,0 +1,84 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { Input } from '@/components/common/Input';
+
+const meta: Meta<typeof Input> = {
+  title: 'Components/Input',
+  component: Input,
+  parameters: {
+    layout: 'centered',
+    backgrounds: {
+      default: 'gray',
+      values: [{ name: 'gray', value: '#C4C4C4' }],
+    },
+    docs: {
+      description: {
+        component: `
+      Input 컴포넌트는 텍스트 및 비밀번호 입력을 처리하는 폼 요소입니다.
+      
+    이 컴포넌트는 기본적으로 사용자가 입력할 수 있는 텍스트 필드를 제공합니다.
+    또한, 비밀번호 입력 필드와 같이 보안 입력을 위해 사용할 수 있습니다.
+    다양한 스타일링 옵션과 함께 사용이 가능합니다.
+
+    width 값은 className으로 넘겨주면 사용 가능합니다.
+    `,
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    type: {
+      options: ['text', 'password'],
+      control: { type: 'select' },
+      description: '입력 필드의 타입',
+    },
+    placeholder: {
+      control: { type: 'text' },
+      description: '입력 필드에 표시될 기본 텍스트',
+      defaultValue: 'Enter text',
+    },
+    disabled: {
+      control: { type: 'boolean' },
+      description: '입력 필드를 비활성화할지 여부',
+      defaultValue: false,
+    },
+    value: {
+      control: { type: 'text' },
+      description: '입력 필드의 값',
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Input>;
+
+export const _Default: Story = {
+  args: {
+    type: 'text',
+    placeholder: 'placeholder',
+  },
+};
+
+export const _PasswordInput: Story = {
+  args: {
+    type: 'password',
+    value: 'password',
+    placeholder: 'enter password',
+  },
+};
+
+export const _DisabledInput: Story = {
+  args: {
+    type: 'text',
+    placeholder: 'nope',
+    disabled: true,
+  },
+};
+
+export const _LargeInput: Story = {
+  args: {
+    type: 'text',
+    placeholder: 'Large',
+    className: 'w-600',
+  },
+};

--- a/src/components/common/Input/index.tsx
+++ b/src/components/common/Input/index.tsx
@@ -7,7 +7,7 @@ export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
 export const Input = React.forwardRef<HTMLInputElement, InputProps>(
   ({ className, type = 'text', ...props }, ref) => {
     const inputClass = cn(
-      'w-full px-24 py-12 outline-none bg-slate-50 rounded-12 text-sm-normal md:text-base-normal',
+      'w-full px-24 py-12 outline-none bg-white rounded-12 text-sm-normal md:text-base-normal',
       className,
     );
 

--- a/src/components/common/Input/index.tsx
+++ b/src/components/common/Input/index.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import { forwardRef } from 'react';
 
 import { cn } from '@/utils/className';
 
 export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
 
-export const Input = React.forwardRef<HTMLInputElement, InputProps>(
+export const Input = forwardRef<HTMLInputElement, InputProps>(
   ({ className, type = 'text', ...props }, ref) => {
     const inputClass = cn(
       'w-full px-24 py-12 outline-none bg-white rounded-12 text-sm-normal md:text-base-normal',

--- a/src/components/common/Input/index.tsx
+++ b/src/components/common/Input/index.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+import { cn } from '@/utils/className';
+
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
+
+export const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type = 'text', ...props }, ref) => {
+    const inputClass = cn(
+      'w-full px-24 py-12 outline-none bg-slate-50 rounded-12 text-sm-normal md:text-base-normal',
+      className,
+    );
+
+    return <input ref={ref} type={type} className={inputClass} {...props} />;
+  },
+);
+
+Input.displayName = 'Input';


### PR DESCRIPTION
# 📄 Input 컴포넌트 제작

## 📝 변경 사항 요약
- Input 컴포넌트 제작
- Input 컴포넌트 스토리북 제작

## 📌 관련 이슈
- 이슈 번호: #37 

## 🔍 변경 사항 상세 설명
Input 컴포넌트를 만들었습니다.

사이즈를 특정해서 만들기가 어려워서 일단 width 값은 className으로 넘겨주면 원하는 값으로 사용가능합니다.
> 기본값으로는 `w-full`이 들어가있습니다.

`ref`를 사용할 수 있도록 prop에 ref도 추가시켜놨습니다. (제어 / 비제어)


현재 피그마 상에서 input 컴포넌트 배경색이 흰색이라 스토리북 배경색을 변경했습니다.
그에 따른 스토리북 추가 라이브러리 다운 받았습니다.

## ✅ 확인 사항
- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 관련 테스트를 작성하고 모두 통과했는지 확인했습니다.
- [x] 코드 스타일 가이드에 맞게 작성했습니다.

## 📸 스크린샷 (선택 사항)
<img width="1065" alt="image" src="https://github.com/user-attachments/assets/68bd515c-0575-4ca8-90c5-91df67aadd10">


## 기타 참고 사항
mdx 파일로 스토리북 사용해보고 싶은데 적용이 안되서 다른 방법으로 작성해두었습니다.
