### PR TITLE
[Feat] vercel preview 코멘트 인식(tag)

### DIFF
--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -49,5 +49,6 @@ jobs:
       - name: Comment PR with Preview URL
         uses: thollander/actions-comment-pull-request@v2
         with:
+          comment_tag: ${{ github.event.number }}-vercel-preview
           message: |
             🎉 구현한 기능 Preview: ${{ steps.deploy.outputs.preview_url }}


### PR DESCRIPTION
# 📄 [Feat] vercel preview 코멘트 인식(tag)

## 📝 변경 사항 요약
- vercel 코멘트가 기존 코멘트를 인식하도록 수정

## 📌 관련 이슈
- 이슈 번호: #68 

## 🔍 변경 사항 상세 설명
`comment_tag`를 `${{ github.event.number }}`로, 뒤에 추가로 `-vercel-perview`를 붙여서 인식하도록 해봤습니다

## ✅ 확인 사항
- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 관련 테스트를 작성하고 모두 통과했는지 확인했습니다.
- [x] 코드 스타일 가이드에 맞게 작성했습니다.

## 📸 스크린샷 (선택 사항)


## 기타 참고 사항
Test 커밋 해볼게여
