### PR TITLE
[Refactor] add empty data dashboard page

### DIFF
--- a/src/app/(route)/dashboard/page.tsx
+++ b/src/app/(route)/dashboard/page.tsx
@@ -1,7 +1,10 @@
 import { FaAngleRight } from 'react-icons/fa6';
+
 import { Header } from '@/components/common/Header';
 import { GoalList } from '@/components/Dashboard/GoalList';
 import { MyProgress } from '@/components/Dashboard/MyProgress';
+
+import { Card } from '@/components/common/Card';
 import { GOALS } from '@/constants/DashboardMockData';
 
 export default function DashBoardPage() {
@@ -9,8 +12,17 @@ export default function DashBoardPage() {
     <>
       <Header title="대시보드" />
       <div className="flex min-h-screen w-screen flex-col gap-16 overflow-y-scroll bg-custom-white-100 px-16 pb-16 pt-48">
+        {/* 팔로워 */}
+        <div className="mt-16 w-full">
+          <Card>
+            <p className="text-sm-normal text-custom-gray-100">
+              찍찍이들 팔로우 하고 인증 보기
+            </p>
+          </Card>
+        </div>
+
         {/* 최근 등록 */}
-        <div className="relative mt-16 w-full rounded-12 bg-white p-16">
+        <div className="relative w-full rounded-12 bg-white p-16">
           <p className="text-lg-semibold">최근 등록한 할 일</p>
           <button className="flex-center absolute right-16 top-16 text-sm-medium">
             모두 보기 <FaAngleRight className="ml-8" />
@@ -28,7 +40,7 @@ export default function DashBoardPage() {
           </ul>
         </div>
 
-        <MyProgress progressPercent={74} />
+        <MyProgress progressPercent={0} />
         <GoalList goals={GOALS} />
       </div>
     </>

--- a/src/app/(route)/dashboard/page.tsx
+++ b/src/app/(route)/dashboard/page.tsx
@@ -11,7 +11,6 @@ export default function DashBoardPage() {
       <Header title="대시보드" />
       <div className="flex min-h-screen w-screen flex-col gap-16 overflow-y-scroll bg-custom-white-100 px-16 pb-16 pt-48">
         <Follwer />
-        <div className="-ml-16 h-6 w-screen bg-custom-white-200" />
         <RecentTodos />
         <MyProgress />
         <GoalList />

--- a/src/app/(route)/dashboard/page.tsx
+++ b/src/app/(route)/dashboard/page.tsx
@@ -1,47 +1,20 @@
-import { FaAngleRight } from 'react-icons/fa6';
-
 import { Header } from '@/components/common/Header';
 import { GoalList } from '@/components/Dashboard/GoalList';
 import { MyProgress } from '@/components/Dashboard/MyProgress';
 
-import { Card } from '@/components/common/Card';
-import { GOALS } from '@/constants/DashboardMockData';
+import { Follwer } from '@/components/Dashboard/Follwer';
+import { RecentTodos } from '@/components/Dashboard/RecentTodos';
 
 export default function DashBoardPage() {
   return (
     <>
       <Header title="대시보드" />
       <div className="flex min-h-screen w-screen flex-col gap-16 overflow-y-scroll bg-custom-white-100 px-16 pb-16 pt-48">
-        {/* 팔로워 */}
-        <div className="mt-16 w-full">
-          <Card>
-            <p className="text-sm-normal text-custom-gray-100">
-              찍찍이들 팔로우 하고 인증 보기
-            </p>
-          </Card>
-        </div>
-
-        {/* 최근 등록 */}
-        <div className="relative w-full rounded-12 bg-white p-16">
-          <p className="text-lg-semibold">최근 등록한 할 일</p>
-          <button className="flex-center absolute right-16 top-16 text-sm-medium">
-            모두 보기 <FaAngleRight className="ml-8" />
-          </button>
-          <ul className="text-sm-normal">
-            <li>
-              <span>리스트 1</span>
-            </li>
-            <li>
-              <span>리스트 2</span>
-            </li>
-            <li>
-              <span>리스트 3</span>
-            </li>
-          </ul>
-        </div>
-
-        <MyProgress progressPercent={0} />
-        <GoalList goals={GOALS} />
+        <Follwer />
+        <div className="-ml-16 h-6 w-screen bg-custom-white-200" />
+        <RecentTodos />
+        <MyProgress />
+        <GoalList />
       </div>
     </>
   );

--- a/src/components/Dashboard/DashboardItemContainer/index.tsx
+++ b/src/components/Dashboard/DashboardItemContainer/index.tsx
@@ -1,0 +1,20 @@
+import { ReactNode } from 'react';
+
+interface DashboardItemContainerProps {
+  title: string;
+  children: ReactNode;
+  className?: string;
+}
+
+export const DashboardItemContainer = ({
+  title,
+  children,
+  className = '',
+}: DashboardItemContainerProps) => {
+  return (
+    <div className={className}>
+      <p className="mb-16 text-xl-semibold">{title}</p>
+      {children}
+    </div>
+  );
+};

--- a/src/components/Dashboard/Follwer/index.tsx
+++ b/src/components/Dashboard/Follwer/index.tsx
@@ -1,0 +1,14 @@
+import { Card } from '@/components/common/Card';
+import { DashboardItemContainer } from '@/components/Dashboard/DashboardItemContainer';
+
+export const Follwer = () => {
+  return (
+    <DashboardItemContainer title="팔로워 현황" className="mt-16">
+      <Card>
+        <p className="text-sm-normal text-custom-gray-100">
+          찍찍이들 팔로우 하고 인증 보기
+        </p>
+      </Card>
+    </DashboardItemContainer>
+  );
+};

--- a/src/components/Dashboard/Follwer/index.tsx
+++ b/src/components/Dashboard/Follwer/index.tsx
@@ -3,12 +3,16 @@ import { DashboardItemContainer } from '@/components/Dashboard/DashboardItemCont
 
 export const Follwer = () => {
   return (
-    <DashboardItemContainer title="팔로워 현황" className="mt-16">
+    <DashboardItemContainer
+      title="팔로워 현황"
+      className="relative mb-22 mt-16"
+    >
       <Card>
         <p className="text-sm-normal text-custom-gray-100">
           찍찍이들 팔로우 하고 인증 보기
         </p>
       </Card>
+      <div className="absolute -bottom-22 -left-16 h-6 w-[calc(100%+32px)] bg-custom-white-200" />
     </DashboardItemContainer>
   );
 };

--- a/src/components/Dashboard/GoalList/GoalItem/TodoList/index.tsx
+++ b/src/components/Dashboard/GoalList/GoalItem/TodoList/index.tsx
@@ -14,7 +14,9 @@ export const TodoList = ({ todo }: TodoListProps) => {
   const [isOpen, setIsOpen] = useState(false);
 
   const handleClickToggle = () => {
-    setIsOpen((prev) => !prev);
+    if (todo.completes.length > 0) {
+      setIsOpen((prev) => !prev);
+    }
   };
 
   return (

--- a/src/components/Dashboard/GoalList/index.tsx
+++ b/src/components/Dashboard/GoalList/index.tsx
@@ -1,17 +1,14 @@
+import { DashboardItemContainer } from '@/components/Dashboard/DashboardItemContainer';
 import { GoalItem } from '@/components/Dashboard/GoalList/GoalItem';
-import { GoalTypes } from '@/constants/DashboardMockData';
 
-interface GoalListProps {
-  goals: GoalTypes[];
-}
+import { GOALS } from '@/constants/DashboardMockData';
 
-export const GoalList = ({ goals }: GoalListProps) => {
+export const GoalList = () => {
   return (
-    <>
-      <p className="text-xl-semibold">목표 별 할 일</p>
-      {goals.map((goal) => (
+    <DashboardItemContainer title="목표 별 할 일">
+      {GOALS.map((goal) => (
         <GoalItem key={goal.id} name={goal.name} todos={goal.todos} />
       ))}
-    </>
+    </DashboardItemContainer>
   );
 };

--- a/src/components/Dashboard/GoalList/index.tsx
+++ b/src/components/Dashboard/GoalList/index.tsx
@@ -12,7 +12,11 @@ export const GoalList = () => {
       {goals.length > 0 ? (
         <>
           {GOALS.map((goal) => (
-            <GoalItem key={goal.id} name={goal.name} todos={goal.todos} />
+            <GoalItem
+              key={goal.goalId}
+              name={goal.goalTitle}
+              todos={goal.todos}
+            />
           ))}
         </>
       ) : (

--- a/src/components/Dashboard/GoalList/index.tsx
+++ b/src/components/Dashboard/GoalList/index.tsx
@@ -1,14 +1,27 @@
+import { Card } from '@/components/common/Card';
 import { DashboardItemContainer } from '@/components/Dashboard/DashboardItemContainer';
 import { GoalItem } from '@/components/Dashboard/GoalList/GoalItem';
 
 import { GOALS } from '@/constants/DashboardMockData';
 
 export const GoalList = () => {
+  const goals = [];
+
   return (
     <DashboardItemContainer title="목표 별 할 일">
-      {GOALS.map((goal) => (
-        <GoalItem key={goal.id} name={goal.name} todos={goal.todos} />
-      ))}
+      {goals.length > 0 ? (
+        <>
+          {GOALS.map((goal) => (
+            <GoalItem key={goal.id} name={goal.name} todos={goal.todos} />
+          ))}
+        </>
+      ) : (
+        <Card>
+          <p className="text-sm-normal text-custom-gray-100">
+            등록된 목표가 없습니다.
+          </p>
+        </Card>
+      )}
     </DashboardItemContainer>
   );
 };

--- a/src/components/Dashboard/MyProgress/ProgressCircle/index.tsx
+++ b/src/components/Dashboard/MyProgress/ProgressCircle/index.tsx
@@ -2,9 +2,12 @@
 
 import { useEffect, useState } from 'react';
 import { motion } from 'motion/react';
-import { MyProgressProps } from '..';
 
-export const ProgressCircle = ({ progressPercent }: MyProgressProps) => {
+export const ProgressCircle = ({
+  progressPercent,
+}: {
+  progressPercent: number;
+}) => {
   const [percent, setPercent] = useState(0);
 
   useEffect(() => {

--- a/src/components/Dashboard/MyProgress/index.tsx
+++ b/src/components/Dashboard/MyProgress/index.tsx
@@ -1,18 +1,20 @@
+'use client';
+
+import { useState } from 'react';
+
+import { DashboardItemContainer } from '@/components/Dashboard/DashboardItemContainer';
 import { ProgressCircle } from '@/components/Dashboard/MyProgress/ProgressCircle';
 import { ProgressNumber } from '@/components/Dashboard/MyProgress/ProgressNumber';
 
-export interface MyProgressProps {
-  progressPercent: number;
-}
+export const MyProgress = () => {
+  const [progressPercent] = useState(0);
 
-export const MyProgress = ({ progressPercent }: MyProgressProps) => {
   return (
-    <>
-      <p className="text-xl-semibold">내 진행 상황</p>
+    <DashboardItemContainer title="내 진행 상황">
       <div className="flex-center relative py-16">
         <ProgressCircle progressPercent={progressPercent} />
         <ProgressNumber progressPercent={progressPercent} />
       </div>
-    </>
+    </DashboardItemContainer>
   );
 };

--- a/src/components/Dashboard/RecentTodos/index.tsx
+++ b/src/components/Dashboard/RecentTodos/index.tsx
@@ -1,6 +1,8 @@
 import { FaAngleRight } from 'react-icons/fa6';
 
 import { DashboardItemContainer } from '@/components/Dashboard/DashboardItemContainer';
+import { Button } from '@/components/common/Button/Button';
+import { Card } from '@/components/common/Card';
 
 export const RecentTodos = () => {
   return (
@@ -8,17 +10,12 @@ export const RecentTodos = () => {
       <button className="flex-center absolute right-0 top-0 text-sm-medium text-custom-gray-100">
         모두 보기 <FaAngleRight className="ml-8" />
       </button>
-      <ul className="text-sm-normal">
-        <li>
-          <span>리스트 1</span>
-        </li>
-        <li>
-          <span>리스트 2</span>
-        </li>
-        <li>
-          <span>리스트 3</span>
-        </li>
-      </ul>
+      <Card>
+        <p className="text-sm-normal text-custom-gray-100">
+          목표 먼저 등록 후 할 일을 설정해주세요.
+        </p>
+        <Button size="medium">새 목표 등록</Button>
+      </Card>
     </DashboardItemContainer>
   );
 };

--- a/src/components/Dashboard/RecentTodos/index.tsx
+++ b/src/components/Dashboard/RecentTodos/index.tsx
@@ -1,0 +1,24 @@
+import { FaAngleRight } from 'react-icons/fa6';
+
+import { DashboardItemContainer } from '@/components/Dashboard/DashboardItemContainer';
+
+export const RecentTodos = () => {
+  return (
+    <DashboardItemContainer title="최근 등록한 할일" className="relative">
+      <button className="flex-center absolute right-0 top-0 text-sm-medium text-custom-gray-100">
+        모두 보기 <FaAngleRight className="ml-8" />
+      </button>
+      <ul className="text-sm-normal">
+        <li>
+          <span>리스트 1</span>
+        </li>
+        <li>
+          <span>리스트 2</span>
+        </li>
+        <li>
+          <span>리스트 3</span>
+        </li>
+      </ul>
+    </DashboardItemContainer>
+  );
+};

--- a/src/components/common/Card/index.tsx
+++ b/src/components/common/Card/index.tsx
@@ -5,7 +5,6 @@ import { cn } from '@/utils/className';
 interface CardProps {
   children: ReactNode;
   className?: string;
-  hasShadow?: boolean;
 }
 
 export const Card = ({ children, className }: CardProps) => {

--- a/src/components/common/Card/index.tsx
+++ b/src/components/common/Card/index.tsx
@@ -10,7 +10,7 @@ interface CardProps {
 
 export const Card = ({ children, className }: CardProps) => {
   const cardClass = cn(
-    'flex-center w-full flex-col gap-10 rounded-16 bg-white py-65',
+    'flex-center w-full flex-col gap-12 rounded-16 bg-white py-65',
     className,
   );
 

--- a/src/components/common/Card/index.tsx
+++ b/src/components/common/Card/index.tsx
@@ -1,0 +1,18 @@
+import { ReactNode } from 'react';
+
+import { cn } from '@/utils/className';
+
+interface CardProps {
+  children: ReactNode;
+  className?: string;
+  hasShadow?: boolean;
+}
+
+export const Card = ({ children, className }: CardProps) => {
+  const cardClass = cn(
+    'flex-center w-full flex-col gap-10 rounded-16 bg-white py-65',
+    className,
+  );
+
+  return <div className={cardClass}>{children}</div>;
+};

--- a/src/components/common/Header/index.tsx
+++ b/src/components/common/Header/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { FaBarsStaggered } from 'react-icons/fa6';
+import { FaBarsStaggered, FaBell } from 'react-icons/fa6';
 import { useSidebarStore } from '@/store/useSidebarStore';
 
 interface HeaderProps {
@@ -11,12 +11,16 @@ export const Header = ({ title = '' }: HeaderProps) => {
   const { open } = useSidebarStore();
 
   return (
-    <div className="fixed left-0 top-0 z-10 flex h-48 w-full items-center bg-white px-16 md:hidden">
-      <FaBarsStaggered
-        className="w-24 cursor-pointer text-primary-100"
-        onClick={open}
-      />
-      <p className="ml-16 text-base-semibold">{title}</p>
+    <div className="fixed left-0 top-0 z-10 flex h-48 w-full items-center justify-between bg-white px-16 md:hidden">
+      <div className="flex items-center">
+        <FaBarsStaggered
+          className="w-24 cursor-pointer text-primary-100"
+          onClick={open}
+          style={{ strokeWidth: 15 }}
+        />
+        <p className="ml-16 text-base-semibold">{title}</p>
+      </div>
+      <FaBell className="right-0 size-24 cursor-pointer p-4 text-primary-100" />
     </div>
   );
 };

--- a/src/constants/DashboardMockData.ts
+++ b/src/constants/DashboardMockData.ts
@@ -21,15 +21,15 @@ export interface TodoTypes {
 }
 
 export interface GoalTypes {
-  id: number;
-  name: string;
+  goalId: number;
+  goalTitle: string;
   todos: TodoTypes[];
 }
 
 export const GOALS: GoalTypes[] = [
   {
-    id: 1,
-    name: '토익 700점 맞기',
+    goalId: 1,
+    goalTitle: '토익 700점 맞기',
     todos: [
       {
         todoId: 1,
@@ -90,8 +90,8 @@ export const GOALS: GoalTypes[] = [
     ],
   },
   {
-    id: 2,
-    name: 'JavaScript 기본 공부하기',
+    goalId: 2,
+    goalTitle: 'JavaScript 기본 공부하기',
     todos: [
       {
         todoId: 3,


### PR DESCRIPTION
# 📄 대시보드 페이지 할일, 목표 없을 때 화면 추가

## 📝 변경 사항 요약
- 팔로우 현황 추가
- 목표나 할일이 없을 때의 레이아웃 추가

## 📌 관련 이슈
- 이슈 번호: #75

## 🔍 변경 사항 상세 설명
### 팔로우 현황
현재는 후순위 개발이라 항상 비어있는 화면으로 설정해두었습니다.

### 목표, 할일이 없는 경우
각각에 맞는 카드를 배치해두었습니다.

### 헤더
헤더에 알람 아이콘 설정해두었습니다.
피그마엔 색상이 회색으로 되어있는데 primary 색이 조금 더 잘 어울려서 일단 해두었습니다.

## ✅ 확인 사항
- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 관련 테스트를 작성하고 모두 통과했는지 확인했습니다.
- [x] 코드 스타일 가이드에 맞게 작성했습니다.

## 📸 스크린샷 (선택 사항)
<img width="385" alt="image" src="https://github.com/user-attachments/assets/b918ef6d-2e4f-448e-a737-660123844191">


## 기타 참고 사항
할일 인증 사진 부분은 api 연동하면서 작업해야할 것 같습니다.
