### PR TITLE
[Refactor] login api for header token

### DIFF
--- a/src/apis/Auth/signin.ts
+++ b/src/apis/Auth/signin.ts
@@ -1,16 +1,16 @@
-import axios from 'axios';
 import { API_ENDPOINTS } from '@/constants/ApiEndpoints';
 import { AuthDataRequest } from '@/types/Auth/AuthDataRequest';
+import axiosInstance from '../../../lib/axiosInstance';
 
 export const signin = async (data: AuthDataRequest) => {
   const baseurl = process.env.NEXT_PUBLIC_API_URL;
 
   try {
-    const response = await axios.post(
+    const response = await axiosInstance.post(
       baseurl + API_ENDPOINTS.AUTH.SIGN_IN,
       data,
     );
-    return response.data;
+    return response;
   } catch (error) {
     console.error('Error signin:', error);
     throw error;

--- a/src/apis/Auth/signin.ts
+++ b/src/apis/Auth/signin.ts
@@ -1,6 +1,6 @@
 import { API_ENDPOINTS } from '@/constants/ApiEndpoints';
+import axiosInstance from '@/lib/axiosInstance';
 import { AuthDataRequest } from '@/types/Auth/AuthDataRequest';
-import axiosInstance from '../../../lib/axiosInstance';
 
 export const signin = async (data: AuthDataRequest) => {
   try {

--- a/src/apis/Auth/signin.ts
+++ b/src/apis/Auth/signin.ts
@@ -3,13 +3,8 @@ import { AuthDataRequest } from '@/types/Auth/AuthDataRequest';
 import axiosInstance from '../../../lib/axiosInstance';
 
 export const signin = async (data: AuthDataRequest) => {
-  const baseurl = process.env.NEXT_PUBLIC_API_URL;
-
   try {
-    const response = await axiosInstance.post(
-      baseurl + API_ENDPOINTS.AUTH.SIGN_IN,
-      data,
-    );
+    const response = await axiosInstance.post(API_ENDPOINTS.AUTH.SIGN_IN, data);
     return response;
   } catch (error) {
     console.error('Error signin:', error);

--- a/src/apis/Sidebar/getSidebarGoals.ts
+++ b/src/apis/Sidebar/getSidebarGoals.ts
@@ -1,5 +1,5 @@
 import { API_ENDPOINTS } from '@/constants/ApiEndpoints';
-import axiosInstance from '../../lib/axiosInstance';
+import axiosInstance from '@/lib/axiosInstance';
 
 export const getSidebarGoals = async () => {
   try {

--- a/src/apis/Todo/createTodo.ts
+++ b/src/apis/Todo/createTodo.ts
@@ -1,6 +1,6 @@
 import { API_ENDPOINTS } from '@/constants/ApiEndpoints';
 import { CreateTodosRequest } from '@/types/CreateTodos/CreateTodosRequest';
-import axiosInstance from '../../lib/axiosInstance';
+import axiosInstance from '@/lib/axiosInstance';
 
 export const createTodo = async (data: CreateTodosRequest) => {
   try {

--- a/src/hooks/apis/useSignin.ts
+++ b/src/hooks/apis/useSignin.ts
@@ -1,20 +1,19 @@
 import { useMutation, UseMutationResult } from '@tanstack/react-query';
-import { AxiosError } from 'axios';
+import { AxiosError, AxiosResponse } from 'axios';
 import { signin } from '@/apis/Auth/signin';
 import { notify } from '@/store/useToastStore';
-import { AuthDataResponse } from '@/types/Auth/AuthDataResponse';
 import { AuthDataRequest } from '@/types/Auth/AuthDataRequest';
 
 export const useSignin = (): UseMutationResult<
-  AuthDataResponse,
+  AxiosResponse,
   AxiosError,
   AuthDataRequest
 > => {
   return useMutation({
     mutationFn: (data) => signin(data),
-    onSuccess: (data) => {
+    onSuccess: (response) => {
       notify('success', '로그인에 성공하였습니다', 2000);
-      console.log(data); //응답 값 확인을 위한
+      localStorage.setItem('token', response.headers.token);
     },
     onError: (error: AxiosError) => {
       notify('error', '로그인에 실패하였습니다', 2000);

--- a/src/lib/axiosInstance.ts
+++ b/src/lib/axiosInstance.ts
@@ -2,33 +2,27 @@ import axios from 'axios';
 
 const apiUrl = process.env.NEXT_PUBLIC_API_URL;
 
-const token = process.env.NEXT_PUBLIC_TEST_TOKEN;
-
 const axiosInstance = axios.create({
   baseURL: apiUrl,
   headers: {
     'Content-Type': 'application/json',
     Accept: '*/*',
-    token: token, // 여기서 기본 헤더를 설정
   },
 });
 
-// // 요청 인터셉터를 사용하여 토큰을 동적으로 헤더에 추가합니다.
-// axiosInstance.interceptors.request.use(
-//   (config) => {
-//     // 로컬 스토리지에서 토큰을 가져옵니다.
-//     const token = localStorage.getItem('token'); // 또는 쿠키에서 가져올 수도 있음
+axiosInstance.interceptors.request.use(
+  (config) => {
+    const token = localStorage.getItem('token');
 
-//     // 토큰이 있을 경우 Authorization 헤더에 추가
-//     if (token) {
-//       config.headers['Authorization'] = `Bearer ${token}`;
-//     }
+    if (token) {
+      config.headers['token'] = token;
+    }
 
-//     return config;
-//   },
-//   (error) => {
-//     return Promise.reject(error);
-//   },
-// );
+    return config;
+  },
+  (error) => {
+    return Promise.reject(error);
+  },
+);
 
 export default axiosInstance;


### PR DESCRIPTION
# 📄 [Refactor] login api for header token

## 📝 변경 사항 요약
- 응답 헤더를 통해 토큰을 방식으로 로그인 로직을 변경하였습니다.
- 토큰을 local storage에 저장하는 방식으로 진행하였습니다. 

## 📌 관련 이슈
- 이슈 번호: #83 

## 🔍 변경 사항 상세 설명
axiosInstance 파일에서 토큰 관련 인터셉터 코드를 추가하였습니다.
로그인 mutation 훅에서 성공 시 헤더의 토큰을 저장하는 로직으로 구성하였습니다.

## ✅ 확인 사항
- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 관련 테스트를 작성하고 모두 통과했는지 확인했습니다.
- [x] 코드 스타일 가이드에 맞게 작성했습니다.
