### PR TITLE
[Refactor] 로그인 성공시 페이지 이동 및 axios 인스턴스로 리다이렉션

### DIFF
--- a/src/hooks/apis/Auth/useSignin.ts
+++ b/src/hooks/apis/Auth/useSignin.ts
@@ -1,5 +1,6 @@
 import { useMutation, UseMutationResult } from '@tanstack/react-query';
 import { AxiosError, AxiosResponse } from 'axios';
+import { useRouter } from 'next/navigation';
 import { signin } from '@/apis/Auth/signin';
 import { notify } from '@/store/useToastStore';
 import { AuthDataRequest } from '@/types/Auth/AuthDataRequest';
@@ -9,11 +10,13 @@ export const useSignin = (): UseMutationResult<
   AxiosError,
   AuthDataRequest
 > => {
+  const router = useRouter();
+
   return useMutation({
     mutationFn: (data) => signin(data),
-    onSuccess: (response) => {
+    onSuccess: () => {
       notify('success', '로그인에 성공하였습니다', 3000);
-      localStorage.setItem('token', response.headers.token);
+      router.push('/dashboard');
     },
     onError: (error: AxiosError) => {
       notify('error', '로그인에 실패하였습니다', 3000);

--- a/src/lib/axiosInstance.ts
+++ b/src/lib/axiosInstance.ts
@@ -8,19 +8,17 @@ const axiosInstance = axios.create({
     'Content-Type': 'application/json',
     Accept: '*/*',
   },
+  withCredentials: true,
 });
 
-axiosInstance.interceptors.request.use(
-  (config) => {
-    const token = localStorage.getItem('token');
-
-    if (token) {
-      config.headers['token'] = token;
-    }
-
-    return config;
+axiosInstance.interceptors.response.use(
+  (response) => {
+    return response;
   },
   (error) => {
+    if (error.response && error.response.status === 401) {
+      window.location.href = '/signin';
+    }
     return Promise.reject(error);
   },
 );


### PR DESCRIPTION
# 📄 로그인 성공시 페이지 이동 및 axios 인스턴스로 리다이렉션

## 📝 변경 사항 요약
- 후우.. 쿠키로 토큰을 불어와지는 것은 잘되었으나 서버와의 도메인이 달라 middleware에서 토큰을 불러올 수 없었습니다.
[https://velog.io/@jojeon4515/서로-다른-도메인에서-쿠키-사용하기-React-Express](https://velog.io/@jojeon4515/%EC%84%9C%EB%A1%9C-%EB%8B%A4%EB%A5%B8-%EB%8F%84%EB%A9%94%EC%9D%B8%EC%97%90%EC%84%9C-%EC%BF%A0%ED%82%A4-%EC%82%AC%EC%9A%A9%ED%95%98%EA%B8%B0-React-Express)
- 결국 axiosInstance에서 401(인증 오류)가 떴을 때 라이렉션해주는 방법으로 선택
- 로그인 성공 시 대시보드 페이지로 이동

## 📌 관련 이슈
- 이슈 번호: #71 

## ✅ 확인 사항
- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 관련 테스트를 작성하고 모두 통과했는지 확인했습니다.
- [x] 코드 스타일 가이드에 맞게 작성했습니다.

## 📸 스크린샷 (선택 사항)
변경 사항을 시각적으로 확인할 수 있는 스크린샷을 여기에 첨부해주세요.

## 기타 참고 사항
이 부분에 대해서는 멘토님에게 피드백을 받아봐야할 것 같습니다.
