### PR TITLE
[Refactor] 할일 생성 성공 시 쿼리키 무효화 후 모달 닫기

### DIFF
--- a/src/hooks/apis/Todo/useCreateTodo.ts
+++ b/src/hooks/apis/Todo/useCreateTodo.ts
@@ -1,19 +1,31 @@
-import { useMutation, UseMutationResult } from '@tanstack/react-query';
+import {
+  useMutation,
+  UseMutationResult,
+  useQueryClient,
+} from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 import { createTodo } from '@/apis/Todo/createTodo';
 import { CreateTodosRequest } from '@/types/CreateTodos/CreateTodosRequest';
 import { CreateTodoResponse } from '@/types/CreateTodos/CreateTodosResponse';
 import { notify } from '@/store/useToastStore';
+import { QUERY_KEYS } from '@/constants/QueryKeys';
+import { useTodoModalStore } from '@/store/useTodoModalStore';
 
 export const useCreateTodo = (): UseMutationResult<
   CreateTodoResponse,
   AxiosError,
   CreateTodosRequest
 > => {
+  const queryClient = useQueryClient();
+  const { close } = useTodoModalStore();
+
   return useMutation<CreateTodoResponse, AxiosError, CreateTodosRequest>({
     mutationFn: (data) => createTodo(data),
     onSuccess: () => {
       notify('success', '할 일 등록에 성공하였습니다', 2000);
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.TODOS_OF_GOALS] });
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.RECENT_TODOS] });
+      close();
     },
     onError: (error: AxiosError) => {
       notify('error', '할 일 등록에 실패하였습니다', 2000);


### PR DESCRIPTION
# 📄 할일 생성 성공 시 쿼리키 무효화 후 모달 닫기

## 📝 변경 사항 요약
- 할 일 생성 성공 시에 쿼리 무효화를 통해 실시간으로 변하도록 수정 후 모달 닫기


## 📌 관련 이슈
- 이슈 번호: #100 

## 🔍 변경 사항 상세 설명
자세한 변경 사항을 여기에 작성해주세요. 왜 이러한 변경이 필요한지, 어떻게 구현했는지 등을 포함합니다.

## ✅ 확인 사항
- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 관련 테스트를 작성하고 모두 통과했는지 확인했습니다.
- [x] 코드 스타일 가이드에 맞게 작성했습니다.

## 📸 스크린샷 (선택 사항)
![할일 생성 개선사항](https://github.com/user-attachments/assets/c29e9d31-8f2d-4179-bf2e-a530dda4c86f)


## 기타 참고 사항
notify 두줄이 거슬리네요...
