### PR TITLE
[Feat] create user info in sidebar

### DIFF
--- a/src/apis/getGoals.ts
+++ b/src/apis/getGoals.ts
@@ -1,13 +1,13 @@
 import { API_ENDPOINTS } from '@/constants/ApiEndpoints';
 import axiosInstance from '@/lib/axiosInstance';
 
-export const getSidebarGoals = async () => {
+export const getGoals = async () => {
   try {
     const response = await axiosInstance.get(API_ENDPOINTS.GOAL.GOALS);
 
     return response.data;
   } catch (error) {
-    console.error('사이드바 목표 불러오기 에러', error);
+    console.error('목표 불러오기 에러', error);
     throw error;
   }
 };

--- a/src/apis/services/httpMethod.ts
+++ b/src/apis/services/httpMethod.ts
@@ -1,0 +1,17 @@
+import axiosInstance from '@/lib/axiosInstance';
+
+export async function GET<T>(url: string): Promise<T> {
+  return (await axiosInstance.get(url)).data;
+}
+
+export async function POST<T, U>(url: string, data: U): Promise<T> {
+  return (await axiosInstance.post(url, data)).data;
+}
+
+export async function PUT<T, U>(url: string, data: U): Promise<T> {
+  return (await axiosInstance.put(url, data)).data;
+}
+
+export async function DELETE<T>(url: string): Promise<T> {
+  return (await axiosInstance.delete(url)).data;
+}

--- a/src/components/Sidebar/Profle/index.tsx
+++ b/src/components/Sidebar/Profle/index.tsx
@@ -1,11 +1,15 @@
+import { useUserQuery } from '@/hooks/apis/useUserQuery';
+
 export const Profile = () => {
+  const { email, name } = useUserQuery();
+
   return (
     <div className="flex w-full gap-8 p-16">
       <div className="size-37 shrink-0 rounded-8 bg-slate-200" />
       <div className="flex w-full justify-between">
         <div>
-          <p className="text-sm-medium">체다치즈</p>
-          <p className="text-xs-medium">email</p>
+          <p className="text-sm-medium">{name}</p>
+          <p className="text-xs-medium">{email}</p>
         </div>
         <button className="text-xs-normal">로그아웃</button>
       </div>

--- a/src/constants/ApiEndpoints.ts
+++ b/src/constants/ApiEndpoints.ts
@@ -11,6 +11,7 @@ export const API_ENDPOINTS = {
   AUTH: {
     SIGN_IN: '/api/v1/auths/login',
     SIGN_UP: '/api/v1/auths/signup',
+    USER: '/api/v1/auths/user',
   },
   GOAL: {
     GOALS: '/api/v1/goals',

--- a/src/constants/QueryKeys.ts
+++ b/src/constants/QueryKeys.ts
@@ -3,4 +3,5 @@ export const QUERY_KEYS = {
   TODOS_OF_GOALS: 'todosOfGoals',
   TODAY_PROGRESS: 'todayProgress',
   RECENT_TODOS: 'recentTodos',
+  USER_INFO: 'userInfo',
 };

--- a/src/hooks/apis/useGoalsQuery.ts
+++ b/src/hooks/apis/useGoalsQuery.ts
@@ -2,7 +2,7 @@ import { AxiosError } from 'axios';
 
 import { useQuery, UseQueryOptions } from '@tanstack/react-query';
 
-import { getSidebarGoals } from '@/apis/Sidebar/getSidebarGoals';
+import { getGoals } from '@/apis/getGoals';
 import { QUERY_KEYS } from '@/constants/QueryKeys';
 import { Goal } from '@/types/Goals';
 
@@ -14,7 +14,7 @@ interface GoalsResponse {
 
 const goalsOptions: UseQueryOptions<GoalsResponse, AxiosError> = {
   queryKey: [QUERY_KEYS.SIDEBAR_GOALS],
-  queryFn: getSidebarGoals,
+  queryFn: getGoals,
 };
 
 export const useGoalsQuery = () => {

--- a/src/hooks/apis/useUserQuery.ts
+++ b/src/hooks/apis/useUserQuery.ts
@@ -1,0 +1,34 @@
+import { useQuery, UseQueryOptions } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+
+import { API_ENDPOINTS } from '@/constants/ApiEndpoints';
+import { QUERY_KEYS } from '@/constants/QueryKeys';
+import axiosInstance from '@/lib/axiosInstance';
+import { BaseResponse } from '@/types/response';
+
+interface UserResponse {
+  email: string;
+  name: string;
+}
+
+interface UserInfoResponse extends BaseResponse {
+  data: UserResponse;
+}
+
+const getUserInfo = async () => {
+  const response = await axiosInstance.get(API_ENDPOINTS.AUTH.USER);
+  return response.data;
+};
+
+const userInfoOptions: UseQueryOptions<UserInfoResponse, AxiosError> = {
+  queryKey: [QUERY_KEYS.USER_INFO],
+  queryFn: getUserInfo,
+};
+
+export const useUserQuery = () => {
+  const { data, isLoading, isError, error } = useQuery(userInfoOptions);
+  const email = data?.data.email ?? '';
+  const name = data?.data.name ?? '';
+
+  return { email, name, isLoading, isError, error };
+};

--- a/src/hooks/apis/useUserQuery.ts
+++ b/src/hooks/apis/useUserQuery.ts
@@ -1,9 +1,9 @@
 import { useQuery, UseQueryOptions } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 
+import { GET } from '@/apis/services/httpMethod';
 import { API_ENDPOINTS } from '@/constants/ApiEndpoints';
 import { QUERY_KEYS } from '@/constants/QueryKeys';
-import axiosInstance from '@/lib/axiosInstance';
 import { BaseResponse } from '@/types/response';
 
 interface UserResponse {
@@ -15,14 +15,9 @@ interface UserInfoResponse extends BaseResponse {
   data: UserResponse;
 }
 
-const getUserInfo = async () => {
-  const response = await axiosInstance.get(API_ENDPOINTS.AUTH.USER);
-  return response.data;
-};
-
 const userInfoOptions: UseQueryOptions<UserInfoResponse, AxiosError> = {
   queryKey: [QUERY_KEYS.USER_INFO],
-  queryFn: getUserInfo,
+  queryFn: () => GET<UserInfoResponse>(API_ENDPOINTS.AUTH.USER),
 };
 
 export const useUserQuery = () => {


### PR DESCRIPTION
# 📄 사이드바 유저 정보 api 연동

## 📝 변경 사항 요약
- 사이드바 유저정보 api 연동
- 공통 http method 함수 생성

## 📌 관련 이슈
- 이슈 번호: #105 

## 🔍 변경 사항 상세 설명
### 사이드바 유저 정보 api 연동
`/hooks/api/useUserQuery` 로 `email`, `name` 불러오도록 구현하였습니다.

### 공통 http method 함수 생성
`/apis` 폴더 안에 따로 정리할 필요 없이 `hooks/apis` 폴더 안에 `useQuery`, `useMutation` 사용하는 훅 만들 때 가져와서 사용할 수 있도록 했습니다.
대부분의 응답이 `data`만 받아오기 때문에 `data`만 받아올 수 있도록 했고 에러 처리는 `axios`의 `interceptor`가 공통적으로 하거나 `react query`의 `onError`로 설정할 수 있습니다.

> signin, signup 부분은 header의 쿠키값을 가져와야해서 적용이 될지는 잘 모르겠습니다ㅠ
> MVP 이후에 이 방식으로 수정하거나 다른 좋은 방식이 있으면 해당 방식으로 수정하면 될 것 같습니다.

**GET 예시**
```js
  const userInfoOptions: UseQueryOptions<UserInfoResponse, AxiosError> = {
    queryKey: [QUERY_KEYS.USER_INFO],
    queryFn: () => GET<UserInfoResponse>(API_ENDPOINTS.AUTH.USER),
  };
```

## ✅ 확인 사항
- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 관련 테스트를 작성하고 모두 통과했는지 확인했습니다.
- [x] 코드 스타일 가이드에 맞게 작성했습니다.

## 📸 스크린샷 (선택 사항)
<img width="387" alt="image" src="https://github.com/user-attachments/assets/22e9d6a9-f098-4741-a97d-84539dbd002e" />

## 기타 참고 사항

