### PR TITLE
[Refactor] Sync Goal Value on Add Task Button Click

### DIFF
--- a/src/components/Dashboard/GoalList/GoalItem/GoalHeader/index.tsx
+++ b/src/components/Dashboard/GoalList/GoalItem/GoalHeader/index.tsx
@@ -2,14 +2,23 @@ import { FaFlag, FaPlus } from 'react-icons/fa6';
 
 import TodoModal from '@/components/TodoModal/TodoModalContainer';
 import { useTodoModalStore } from '@/store/useTodoModalStore';
+import { useTodoDataStore } from '@/store/useTodoDataStore';
 
 interface GoalHeaderProps {
+  id: number;
   title: string;
   color: string;
 }
 
-export const GoalHeader = ({ title, color }: GoalHeaderProps) => {
+export const GoalHeader = ({ id, title, color }: GoalHeaderProps) => {
   const { isOpen, open } = useTodoModalStore();
+  const { setTodoData, setGoalTitle } = useTodoDataStore();
+
+  const handleClick = () => {
+    open();
+    setTodoData({ goalId: id });
+    setGoalTitle(title);
+  };
 
   return (
     <>
@@ -18,7 +27,7 @@ export const GoalHeader = ({ title, color }: GoalHeaderProps) => {
         {title}
       </span>
       <button
-        onClick={open}
+        onClick={handleClick}
         className="absolute right-16 top-16 flex items-center text-primary-100"
       >
         <FaPlus className="size-24 p-4" />

--- a/src/components/Dashboard/GoalList/GoalItem/index.tsx
+++ b/src/components/Dashboard/GoalList/GoalItem/index.tsx
@@ -7,15 +7,16 @@ import { TodoList } from '@/components/Dashboard/GoalList/GoalItem/TodoList';
 import { TodosResponse } from '@/hooks/apis/Dashboard/useTodosOfGoalsQuery';
 
 interface GoalItemProps {
+  id: number;
   title: string;
   color: string;
   todos: TodosResponse[];
 }
 
-export const GoalItem = ({ title, color, todos }: GoalItemProps) => {
+export const GoalItem = ({ id, title, color, todos }: GoalItemProps) => {
   return (
     <div className="relative w-full rounded-12 bg-white p-16 shadow-sm">
-      <GoalHeader title={title} color={color} />
+      <GoalHeader id={id} title={title} color={color} />
       <ProgressLine percent={0} color={color} />
       {todos.map((todo) => (
         <TodoList key={todo.todoId} todo={todo} color={color} />

--- a/src/components/Dashboard/GoalList/index.tsx
+++ b/src/components/Dashboard/GoalList/index.tsx
@@ -16,6 +16,7 @@ export const GoalList = () => {
           {goals.map((goal) => (
             <GoalItem
               key={goal.goalId}
+              id={goal.goalId}
               title={goal.goalTitle}
               color={goal.goalColor}
               todos={goal.todos}

--- a/src/components/TodoModal/TodoModalGoal/index.tsx
+++ b/src/components/TodoModal/TodoModalGoal/index.tsx
@@ -11,8 +11,7 @@ import { DropdownIcon } from './DropdownIcon';
 
 export const TodoModalGoal = () => {
   const { goals } = useGoalsQuery();
-  const { setTodoData } = useTodoDataStore();
-  const [goalTitle, setGoalTitle] = useState<string>('');
+  const { setTodoData, setGoalTitle, goalTitle } = useTodoDataStore();
   const [isOpenDropdown, setIsOpenDropdown] = useState(false);
 
   const handleDropdown = () => {

--- a/src/hooks/apis/Todo/useCreateTodo.ts
+++ b/src/hooks/apis/Todo/useCreateTodo.ts
@@ -22,13 +22,13 @@ export const useCreateTodo = (): UseMutationResult<
   return useMutation<CreateTodoResponse, AxiosError, CreateTodosRequest>({
     mutationFn: (data) => createTodo(data),
     onSuccess: () => {
-      notify('success', '할 일 등록에 성공하였습니다', 2000);
+      notify('success', '등록에 성공하였습니다', 3000);
       queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.TODOS_OF_GOALS] });
       queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.RECENT_TODOS] });
       close();
     },
     onError: (error: AxiosError) => {
-      notify('error', '할 일 등록에 실패하였습니다', 2000);
+      notify('error', '등록에 실패하였습니다', 3000);
       console.error('Error creating todo:', error.message);
     },
   });

--- a/src/hooks/apis/Todo/useCreateTodo.ts
+++ b/src/hooks/apis/Todo/useCreateTodo.ts
@@ -10,6 +10,7 @@ import { CreateTodoResponse } from '@/types/CreateTodos/CreateTodosResponse';
 import { notify } from '@/store/useToastStore';
 import { QUERY_KEYS } from '@/constants/QueryKeys';
 import { useTodoModalStore } from '@/store/useTodoModalStore';
+import { useTodoDataStore } from '@/store/useTodoDataStore';
 
 export const useCreateTodo = (): UseMutationResult<
   CreateTodoResponse,
@@ -18,6 +19,7 @@ export const useCreateTodo = (): UseMutationResult<
 > => {
   const queryClient = useQueryClient();
   const { close } = useTodoModalStore();
+  const { resetAll } = useTodoDataStore();
 
   return useMutation<CreateTodoResponse, AxiosError, CreateTodosRequest>({
     mutationFn: (data) => createTodo(data),
@@ -25,6 +27,7 @@ export const useCreateTodo = (): UseMutationResult<
       notify('success', '등록에 성공하였습니다', 3000);
       queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.TODOS_OF_GOALS] });
       queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.RECENT_TODOS] });
+      resetAll();
       close();
     },
     onError: (error: AxiosError) => {

--- a/src/lib/axiosInstance.ts
+++ b/src/lib/axiosInstance.ts
@@ -12,19 +12,19 @@ const axiosInstance = axios.create({
 });
 
 // 응답 인터셉터 (서버에서 오는 응답 처리)
-axiosInstance.interceptors.response.use(
-  (response) => {
-    return response;
-  },
-  (error) => {
-    console.log(error.response);
-    // 오류가 발생한 경우, 응답이 401일 때 로그인 페이지로 리디렉션
-    if (error.response && error.response.status === 401) {
-      console.log('401');
-      window.location.href = '/signin';
-    }
-    return Promise.reject(error); // 에러는 그대로 반환
-  },
-);
+// axiosInstance.interceptors.response.use(
+//   (response) => {
+//     return response;
+//   },
+//   (error) => {
+//     console.log(error.response);
+//     // 오류가 발생한 경우, 응답이 401일 때 로그인 페이지로 리디렉션
+//     if (error.response && error.response.status === 401) {
+//       console.log('401');
+//       window.location.href = '/signin';
+//     }
+//     return Promise.reject(error); // 에러는 그대로 반환
+//   },
+// );
 
 export default axiosInstance;

--- a/src/store/useTodoDataStore.ts
+++ b/src/store/useTodoDataStore.ts
@@ -3,7 +3,9 @@ import { CreateTodosRequest } from '@/types/CreateTodos/CreateTodosRequest';
 
 interface TodoDataStore {
   todoData: CreateTodosRequest;
+  goalTitle: string;
   setTodoData: (newData: Partial<CreateTodosRequest>) => void;
+  setGoalTitle: (goalTitle: string) => void;
   resetAll: () => void;
   resetFile: () => void;
   resetLink: () => void;
@@ -18,8 +20,8 @@ export const useTodoDataStore = create<TodoDataStore>((set) => ({
     imageName: '',
     imageEncodedBase64: '',
     goalId: 0,
-    goalTitle: '',
   },
+  goalTitle: '',
 
   setTodoData: (newData: Partial<TodoDataStore>) =>
     set((state) => ({
@@ -27,6 +29,10 @@ export const useTodoDataStore = create<TodoDataStore>((set) => ({
         ...state.todoData,
         ...newData,
       },
+    })),
+  setGoalTitle: (goalTitle: string) =>
+    set(() => ({
+      goalTitle,
     })),
   resetFile: () =>
     set((state) => ({


### PR DESCRIPTION
# 📄 Sync Goal Value on Add Task Button Click

## 📝 변경 사항 요약
 - 목표별 할일에서 목표에 있는 할일 추가 버튼을 누르면 할 일 생성에 있는 목표의 값이 자동으로 바뀌도록
 - test 완료

## 📌 관련 이슈
- 이슈 번호: #111 

## 🔍 변경 사항 상세 설명
의진님이 작업하신 GoalList, GoalItem, GoalHeader에 id props를 추가하였습니다.
목표 주제가 zustand 저장소 실제 전송 데이터에 포함되어있어서 이를 분리하고 따로 관리하도록 하였습니다.

## ✅ 확인 사항
- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 관련 테스트를 작성하고 모두 통과했는지 확인했습니다.
- [x] 코드 스타일 가이드에 맞게 작성했습니다.

## 📸 스크린샷 (선택 사항)
![할일 생성 리팩토링 Gif](https://github.com/user-attachments/assets/8086181f-8674-46ba-a185-02f6ec9440fa)


## 기타 참고 사항
추가로 공유하고 싶은 내용이나 참고 자료가 있다면 여기에 작성해주세요.
