### PR TITLE
[Feat] Add DELETE Api for todo creation & image preview

### DIFF
--- a/src/apis/Todo/deleteTodo.ts
+++ b/src/apis/Todo/deleteTodo.ts
@@ -1,0 +1,14 @@
+import { API_ENDPOINTS } from '@/constants/ApiEndpoints';
+import axiosInstance from '@/lib/axiosInstance';
+
+export const deleteTodo = async (todoId: string | number) => {
+  try {
+    const response = await axiosInstance.delete(
+      API_ENDPOINTS.TODOS.DELETE(todoId),
+    );
+    return response.data;
+  } catch (error) {
+    console.error('Error Delete todo: ', error);
+    throw error;
+  }
+};

--- a/src/components/TodoModal/TodoModalDocs/FileUpload/FileUploadBtn/index.tsx
+++ b/src/components/TodoModal/TodoModalDocs/FileUpload/FileUploadBtn/index.tsx
@@ -1,25 +1,19 @@
-import { GrDocument } from 'react-icons/gr';
 import { FaPlus } from 'react-icons/fa';
 import { PLACEHOLDERS } from '@/constants/Placeholders';
 
 interface FileUploadBtnProps {
-  fileName: string | undefined;
   onClick: () => void;
 }
 
-export const FileUploadBtn = ({ fileName, onClick }: FileUploadBtnProps) => {
+export const FileUploadBtn = ({ onClick }: FileUploadBtnProps) => {
   return (
     <button
       className="inline-flex flex-col items-center justify-center gap-8"
       onClick={onClick}
     >
-      {fileName ? (
-        <GrDocument className="size-24 text-slate-400" />
-      ) : (
-        <FaPlus className="size-24 text-slate-400" />
-      )}
+      <FaPlus className="size-24 text-slate-400" />
       <span className="text-sm-normal text-slate-400 sm:text-base-normal">
-        {fileName ? fileName : PLACEHOLDERS.FILE}
+        {PLACEHOLDERS.FILE}
       </span>
     </button>
   );

--- a/src/components/TodoModal/TodoModalDocs/FileUpload/index.tsx
+++ b/src/components/TodoModal/TodoModalDocs/FileUpload/index.tsx
@@ -1,4 +1,5 @@
 import { ChangeEvent, useRef } from 'react';
+import Image from 'next/image';
 import { motion } from 'motion/react';
 import { todoModalVariants } from '@/constants/motionVariants';
 import { useTodoDataStore } from '@/store/useTodoDataStore';
@@ -33,16 +34,24 @@ export const FileUpload = () => {
       initial="hidden"
       animate="visible"
     >
-      <FileUploadBtn
-        fileName={todoData.imageName}
-        onClick={() => fileUploadRef.current?.click()}
-      />
+      {todoData.imageEncodedBase64 ? (
+        <Image
+          src={todoData.imageEncodedBase64}
+          width={200}
+          height={200}
+          alt="preview"
+          className="size-full rounded-12 object-cover"
+          onClick={() => fileUploadRef.current?.click()}
+        />
+      ) : (
+        <FileUploadBtn onClick={() => fileUploadRef.current?.click()} />
+      )}
       <input
         id="file-input"
         ref={fileUploadRef}
         className="hidden"
         type={'file'}
-        accept="image/*"
+        accept="image/jpeg, image/jpg, image/png"
         onChange={handleFileName}
       />
     </motion.div>

--- a/src/constants/ApiEndpoints.ts
+++ b/src/constants/ApiEndpoints.ts
@@ -2,7 +2,8 @@ export const API_ENDPOINTS = {
   TODOS: {
     GET_ALL: '/api/v1/todos',
     CREATE: '/api/v1/todos',
-    PUT: (todoId: string | number) => `api/vi/todos/${todoId}`,
+    PUT: (todoId: string | number) => `api/v1/todos/${todoId}`,
+    DELETE: (todoId: string | number) => `api/v1/todos/${todoId}`,
     GET_GOALS: '/api/v1/todos/goals',
     GET_GOAL_BY_ID: (goalId: string | number) =>
       `/api/v1/todos/goals/${goalId}`,

--- a/src/constants/Placeholders.ts
+++ b/src/constants/Placeholders.ts
@@ -2,7 +2,7 @@ export const PLACEHOLDERS = {
   TARGET: '목표를 선택해주세요',
   TITLE_TODO: '할 일의 제목을 적어주세요',
   FILE: '파일을 업로드해주세요',
-  LINK_INPUT: '영상이나 글, 파일의 링크를 넣어주세요',
+  LINK_INPUT: '링크를 첨부해주세요',
   DATE_RANGE: '날짜 범위를 선택해주세요',
   NAME: '이름을 입력해주세요',
   EMAIL: '이메일을 입력해주세요',

--- a/src/hooks/apis/Todo/useDeleteTodo.ts
+++ b/src/hooks/apis/Todo/useDeleteTodo.ts
@@ -1,0 +1,34 @@
+import {
+  useMutation,
+  UseMutationResult,
+  useQueryClient,
+} from '@tanstack/react-query';
+import { AxiosError, AxiosResponse } from 'axios';
+import { notify } from '@/store/useToastStore';
+import { QUERY_KEYS } from '@/constants/QueryKeys';
+import { deleteTodo } from '@/apis/Todo/deleteTodo';
+
+interface DeleteMutationProps {
+  todoId: string | number;
+}
+
+export const useDeleteTodo = (): UseMutationResult<
+  AxiosResponse,
+  AxiosError,
+  DeleteMutationProps
+> => {
+  const queryClient = useQueryClient();
+
+  return useMutation<AxiosResponse, AxiosError, DeleteMutationProps>({
+    mutationFn: ({ todoId }: DeleteMutationProps) => deleteTodo(todoId),
+    onSuccess: () => {
+      notify('success', '삭제에 성공하였습니다', 3000);
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.TODOS_OF_GOALS] });
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.RECENT_TODOS] });
+    },
+    onError: (error: AxiosError) => {
+      notify('error', '삭제에 실패하였습니다', 3000);
+      console.error('Error Delete todo:', error.message);
+    },
+  });
+};

--- a/src/utils/todoDataMappers.ts
+++ b/src/utils/todoDataMappers.ts
@@ -1,43 +1,37 @@
 import { COMMON_TODO_DATA } from '@/constants/Todos/CommonTodoData';
 
-export const getCreateTodoData = (todoData: typeof COMMON_TODO_DATA) => {
-  const {
-    title,
-    startDate,
-    endDate,
-    todoLink,
-    imageName,
-    imageEncodedBase64,
-    goalId,
-  } = todoData;
-  return {
-    title,
-    startDate,
-    endDate,
-    todoLink,
-    imageName,
-    imageEncodedBase64,
-    goalId,
-  };
-};
+export const getCreateTodoData = ({
+  title,
+  startDate,
+  endDate,
+  todoLink,
+  imageName,
+  imageEncodedBase64,
+  goalId,
+}: typeof COMMON_TODO_DATA) => ({
+  title,
+  startDate,
+  endDate,
+  todoLink,
+  imageName,
+  imageEncodedBase64,
+  goalId,
+});
 
-export const getModifyTodoData = (todoData: typeof COMMON_TODO_DATA) => {
-  const {
-    title,
-    startDate,
-    endDate,
-    todoStatus,
-    todoLink,
-    imageName,
-    imageEncodedBase64,
-  } = todoData;
-  return {
-    title,
-    startDate,
-    endDate,
-    todoLink,
-    todoStatus,
-    imageName,
-    imageEncodedBase64,
-  };
-};
+export const getModifyTodoData = ({
+  title,
+  startDate,
+  endDate,
+  todoStatus,
+  todoLink,
+  imageName,
+  imageEncodedBase64,
+}: typeof COMMON_TODO_DATA) => ({
+  title,
+  startDate,
+  endDate,
+  todoStatus,
+  todoLink,
+  imageName,
+  imageEncodedBase64,
+});


### PR DESCRIPTION
# 📄 Add DELETE Api for todo creation & image preview

## 📝 변경 사항 요약
- 이미지 미리보기 기능을 추가했습니다.
- 할일 삭제 관련 api 연동을 하였습니다.

## 📌 관련 이슈
- 이슈 번호: #110 

## 🔍 변경 사항 상세 설명
이미지 미리보기는 base64로 처리
할일 삭제는 mutation 커스텀 훅으로 진행하였음.
test는 임시로 클릭을 하였을 때 할일이 삭제되도록 만들었습니다.

## ✅ 확인 사항
- [ ] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [ ] 관련 테스트를 작성하고 모두 통과했는지 확인했습니다.
- [ ] 코드 스타일 가이드에 맞게 작성했습니다.

## 📸 스크린샷 (선택 사항)
이미지 미리보기
![이미지 미리보기 Gif](https://github.com/user-attachments/assets/791fc7ac-ccfc-48b3-8e10-63a4b33f8add)

할일 삭제
![할일 삭제 Test Gif](https://github.com/user-attachments/assets/04c78789-b11b-4328-8f9f-92ed3f811d5e)


## 기타 참고 사항
추가로 공유하고 싶은 내용이나 참고 자료가 있다면 여기에 작성해주세요.
