### PR TITLE
[Refactor] change token handling cookie to header

### DIFF
--- a/src/apis/Auth/signin.ts
+++ b/src/apis/Auth/signin.ts
@@ -1,10 +1,15 @@
-import { API_ENDPOINTS } from '@/constants/ApiEndpoints';
 import axiosInstance from '@/lib/axiosInstance';
-import { AuthDataRequest } from '@/types/Auth/AuthDataRequest';
+
+import { API_ENDPOINTS } from '@/constants/ApiEndpoints';
+import { useTokenStore } from '@/store/useTokenStore';
+import type { AuthDataRequest } from '@/types/Auth/AuthDataRequest';
 
 export const signin = async (data: AuthDataRequest) => {
   try {
     const response = await axiosInstance.post(API_ENDPOINTS.AUTH.SIGN_IN, data);
+
+    useTokenStore.getState().setToken(response.headers.token || '');
+
     return response;
   } catch (error) {
     console.error('Error signin:', error);

--- a/src/lib/axiosInstance.ts
+++ b/src/lib/axiosInstance.ts
@@ -1,5 +1,7 @@
 import axios from 'axios';
 
+import { useTokenStore } from '@/store/useTokenStore';
+
 const apiUrl = process.env.NEXT_PUBLIC_API_URL;
 
 const axiosInstance = axios.create({
@@ -8,7 +10,20 @@ const axiosInstance = axios.create({
     'Content-Type': 'application/json',
     Accept: '*/*',
   },
-  withCredentials: true,
 });
 
+axiosInstance.interceptors.request.use(
+  (config) => {
+    const token = useTokenStore.getState().token;
+
+    if (token) {
+      config.headers['token'] = token;
+    }
+
+    return config;
+  },
+  (error) => {
+    return Promise.reject(error);
+  },
+);
 export default axiosInstance;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,27 +1,27 @@
-import { NextResponse, type NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
 
 export const config = {
   matcher: ['/((?!api|_next/static|_next/image|favicon.ico).*)'],
 };
 
-const AUTH_PAGES = ['/signup', '/signin'];
+// const AUTH_PAGES = ['/signup', '/signin'];
 
-export const middleware = async (request: NextRequest) => {
-  const { nextUrl, cookies } = request;
-  const { pathname } = nextUrl;
+export const middleware = async () => {
+  // const { nextUrl, cookies } = request;
+  // const { pathname } = nextUrl;
 
-  const token = cookies.get('token');
+  // const token = cookies.get('token');
 
-  if (AUTH_PAGES.some((page) => pathname.startsWith(page))) {
-    if (token) {
-      return NextResponse.redirect(new URL('/dashboard', request.url));
-    }
-    return NextResponse.next();
-  }
+  // if (AUTH_PAGES.some((page) => pathname.startsWith(page))) {
+  //   if (token) {
+  //     return NextResponse.redirect(new URL('/dashboard', request.url));
+  //   }
+  //   return NextResponse.next();
+  // }
 
-  if (!token) {
-    return NextResponse.redirect(new URL('/signin', request.url));
-  }
+  // if (!token) {
+  //   return NextResponse.redirect(new URL('/signin', request.url));
+  // }
 
   return NextResponse.next();
 };

--- a/src/store/useTokenStore.ts
+++ b/src/store/useTokenStore.ts
@@ -1,0 +1,11 @@
+import { create } from 'zustand';
+
+interface TokenStore {
+  token: string;
+  setToken: (newToken: string) => void;
+}
+
+export const useTokenStore = create<TokenStore>((set) => ({
+  token: '',
+  setToken: (newToken) => set(() => ({ token: newToken })),
+}));


### PR DESCRIPTION
# 📄 쿠키에서 헤더로 변경

## 📝 변경 사항 요약
- 토큰을 쿠키에서 헤더로 변경

## 📌 관련 이슈
- 이슈 번호: #121 

## 🔍 변경 사항 상세 설명
기존 쿠키로 관리하던 토큰을 헤더로 다시 변경하였습니다.

토큰 관리에 대해 찾아본 결과 일단은 로그인 했을 때 
accessToken은 보안 위험 때문에 메모리에서 관리, 쿠키에 HttpOnly, Secure, SameSite 설정해서 관리하는 방법이 있고
refreshToken은 노출되어도 상관 없는 값이라 쿠키에서 관리하는 방법으로 이해했습니다.

저희가 현재 관리하고 있는 토큰은 accessToken이라 생각되어 zustand로 저장하여 관리하는 방식으로 했습니다.

> 새로고침 하면 메모리에 저장된 값이라 사라져서 다시 로그인 해야됩니다..

> 미들웨어는 이후 수정을 위해 주석처리 해두었습니다.
## ✅ 확인 사항
- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 관련 테스트를 작성하고 모두 통과했는지 확인했습니다.
- [x] 코드 스타일 가이드에 맞게 작성했습니다.

## 기타 참고 사항
신지수님 블로그 참고
https://new-development.tistory.com/15
