### PR TITLE
[Feat] 내 할 일 페이지 api 연동 및 인증 로직 구현

### DIFF
--- a/src/apis/Todo/certifiedTodo.ts
+++ b/src/apis/Todo/certifiedTodo.ts
@@ -1,0 +1,20 @@
+import { API_ENDPOINTS } from '@/constants/ApiEndpoints';
+import { CertifiedTodoRequest } from '@/hooks/apis/Todo/useCertifiedTodo';
+
+import axiosInstance from '@/lib/axiosInstance';
+
+export const certifiedTodo = async (
+  completeId: number,
+  data: CertifiedTodoRequest,
+) => {
+  try {
+    const response = await axiosInstance.put(
+      API_ENDPOINTS.TODOS.PUT_CERTIFIED_TODO(completeId),
+      data,
+    );
+    return response.data;
+  } catch (error) {
+    console.error('Error certified todo: ', error);
+    throw error;
+  }
+};

--- a/src/app/(route)/todos/page.tsx
+++ b/src/app/(route)/todos/page.tsx
@@ -4,7 +4,7 @@ import { TodoContainer } from '@/components/Todos';
 export default function DashBoardPage() {
   return (
     <>
-      <Header title="모든 할 일" />
+      <Header />
       <TodoContainer />
     </>
   );

--- a/src/components/CertifiedModal/index.tsx
+++ b/src/components/CertifiedModal/index.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { ModalContent } from '../common/Modal';
+import { VerificationNote } from '../VerificationNote/VerificationNoteContainer';
+
+interface CertifiedModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export const CertifiedModal = (props: CertifiedModalProps) => {
+  const { isOpen, onClose } = props;
+
+  return (
+    <ModalContent isOpen={isOpen} onClose={onClose}>
+      <VerificationNote />
+    </ModalContent>
+  );
+};

--- a/src/components/CertifiedModal/index.tsx
+++ b/src/components/CertifiedModal/index.tsx
@@ -1,6 +1,8 @@
 'use client';
 
-import { ModalContent } from '../common/Modal';
+import { motion } from 'motion/react';
+import { todoModalVariants } from '@/constants/motionVariants';
+import { ModalContainer } from '../common/Modal';
 import { VerificationNote } from '../VerificationNote/VerificationNoteContainer';
 
 interface CertifiedModalProps {
@@ -11,9 +13,24 @@ interface CertifiedModalProps {
 export const CertifiedModal = (props: CertifiedModalProps) => {
   const { isOpen, onClose } = props;
 
+  const handleClose = () => {
+    onClose();
+  };
+
+  if (!isOpen) {
+    return null;
+  }
+
   return (
-    <ModalContent isOpen={isOpen} onClose={onClose}>
-      <VerificationNote />
-    </ModalContent>
+    <ModalContainer onClose={handleClose}>
+      <motion.div
+        variants={todoModalVariants}
+        initial="hidden"
+        animate="visible"
+        className="flex size-full flex-col items-start gap-10 overflow-y-auto bg-custom-white-100 px-16 py-24 sm:h-auto sm:w-520 sm:rounded-12 sm:p-24"
+      >
+        <VerificationNote />
+      </motion.div>
+    </ModalContainer>
   );
 };

--- a/src/components/CertifiedModal/index.tsx
+++ b/src/components/CertifiedModal/index.tsx
@@ -36,7 +36,7 @@ export const CertifiedModal = (props: CertifiedModalProps) => {
     }
 
     const data = {
-      completePicBase64: imageUrl, // 실제로는 Base64 인코딩 필요
+      completePicBase64: imageUrl,
       completePicName: completePicName || `${completeId}-image`,
       note: note || '',
       completeLink: completeLink || '임시링크',

--- a/src/components/CertifiedModal/index.tsx
+++ b/src/components/CertifiedModal/index.tsx
@@ -14,6 +14,7 @@ export const CertifiedModal = (props: CertifiedModalProps) => {
   const { isOpen, onClose } = props;
 
   const handleClose = () => {
+    console.log('CertifiedModal 닫기 호출');
     onClose();
   };
 
@@ -29,7 +30,7 @@ export const CertifiedModal = (props: CertifiedModalProps) => {
         animate="visible"
         className="flex size-full flex-col items-start gap-10 overflow-y-auto bg-custom-white-100 px-16 py-24 sm:h-auto sm:w-520 sm:rounded-12 sm:p-24"
       >
-        <VerificationNote />
+        <VerificationNote onClose={handleClose} />
       </motion.div>
     </ModalContainer>
   );

--- a/src/components/CertifiedModal/index.tsx
+++ b/src/components/CertifiedModal/index.tsx
@@ -2,8 +2,11 @@
 
 import { motion } from 'motion/react';
 import { todoModalVariants } from '@/constants/motionVariants';
-import { ModalContainer } from '../common/Modal';
+import { useCertifiedTodo } from '@/hooks/apis/Todo/useCertifiedTodo';
+import { useVerificationNoteStore } from '@/store/useVerificationNoteStore';
+import { notify } from '@/store/useToastStore';
 import { VerificationNote } from '../VerificationNote/VerificationNoteContainer';
+import { ModalContainer } from '../common/Modal';
 
 interface CertifiedModalProps {
   isOpen: boolean;
@@ -12,10 +15,34 @@ interface CertifiedModalProps {
 
 export const CertifiedModal = (props: CertifiedModalProps) => {
   const { isOpen, onClose } = props;
+  const { imageUrl, completePicName, note, completeLink, completeId, reset } =
+    useVerificationNoteStore();
+  const { mutate } = useCertifiedTodo();
 
   const handleClose = () => {
-    console.log('CertifiedModal 닫기 호출');
     onClose();
+    reset();
+  };
+
+  const handleSubmit = () => {
+    if (!completeId) {
+      notify('error', 'completeId가 설정되지 않았습니다.', 3000);
+      return;
+    }
+
+    if (!imageUrl) {
+      notify('error', '이미지가 선택되지 않았습니다.', 3000);
+      return;
+    }
+
+    const data = {
+      completePicBase64: imageUrl, // 실제로는 Base64 인코딩 필요
+      completePicName: completePicName || `${completeId}-image`,
+      note: note || '',
+      completeLink: completeLink || '임시링크',
+    };
+
+    mutate({ completeId, data });
   };
 
   if (!isOpen) {
@@ -30,7 +57,7 @@ export const CertifiedModal = (props: CertifiedModalProps) => {
         animate="visible"
         className="flex size-full flex-col items-start gap-10 overflow-y-auto bg-custom-white-100 px-16 py-24 sm:h-auto sm:w-520 sm:rounded-12 sm:p-24"
       >
-        <VerificationNote onClose={handleClose} />
+        <VerificationNote onClose={handleClose} onSubmit={handleSubmit} />
       </motion.div>
     </ModalContainer>
   );

--- a/src/components/Dashboard/RecentTodos/index.tsx
+++ b/src/components/Dashboard/RecentTodos/index.tsx
@@ -64,9 +64,8 @@ export const RecentTodos = () => {
           {todos.map((todo) => (
             <TodoItem
               key={todo.todoId}
-              title={todo.todoTitle}
-              goal={todo.goalTitle}
-              color={todo.goalColor}
+              todoTitle={todo.todoTitle}
+              todoId={todo.todoId}
             />
           ))}
         </ul>

--- a/src/components/ImageInput/InputModalContent.tsx
+++ b/src/components/ImageInput/InputModalContent.tsx
@@ -32,6 +32,13 @@ export const InputModalContent = (props: InputModalContentProps) => {
     }
   }, [selectedImageUrl, onImageSelected]);
 
+  // Reset selectedImageUrl when the modal is closed
+  useEffect(() => {
+    if (!isOpen) {
+      setSelectedImageUrl('');
+    }
+  }, [isOpen]);
+
   return (
     <ModalContent isOpen={isOpen} onClose={onClose}>
       <h2 className="text-base-medium text-primary-100">

--- a/src/components/ImageInput/InputModalContent.tsx
+++ b/src/components/ImageInput/InputModalContent.tsx
@@ -9,7 +9,7 @@ import { MobileCapture } from './MobileCapture';
 interface InputModalContentProps {
   isOpen: boolean;
   onClose: () => void;
-  onImageSelected?: (imageUrl: string) => void; // New callback prop
+  onImageSelected?: (imageUrl: string) => void;
 }
 
 export const InputModalContent = (props: InputModalContentProps) => {
@@ -25,14 +25,12 @@ export const InputModalContent = (props: InputModalContentProps) => {
     setSelectedImageUrl(imageUrl);
   };
 
-  // Use useEffect to notify parent when an image is selected
   useEffect(() => {
     if (selectedImageUrl && onImageSelected) {
       onImageSelected(selectedImageUrl);
     }
   }, [selectedImageUrl, onImageSelected]);
 
-  // Reset selectedImageUrl when the modal is closed
   useEffect(() => {
     if (!isOpen) {
       setSelectedImageUrl('');

--- a/src/components/ImageInput/InputModalContent.tsx
+++ b/src/components/ImageInput/InputModalContent.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import Image from 'next/image';
 import { ModalContent } from '../common/Modal';
 import { GalleryPicker } from './GalleryPicker';
@@ -9,10 +9,11 @@ import { MobileCapture } from './MobileCapture';
 interface InputModalContentProps {
   isOpen: boolean;
   onClose: () => void;
+  onImageSelected?: (imageUrl: string) => void; // New callback prop
 }
 
 export const InputModalContent = (props: InputModalContentProps) => {
-  const { isOpen, onClose } = props;
+  const { isOpen, onClose, onImageSelected } = props;
 
   const [selectedImageUrl, setSelectedImageUrl] = useState<string>('');
 
@@ -23,6 +24,13 @@ export const InputModalContent = (props: InputModalContentProps) => {
   const handleCapturePhoto = (imageUrl: string) => {
     setSelectedImageUrl(imageUrl);
   };
+
+  // Use useEffect to notify parent when an image is selected
+  useEffect(() => {
+    if (selectedImageUrl && onImageSelected) {
+      onImageSelected(selectedImageUrl);
+    }
+  }, [selectedImageUrl, onImageSelected]);
 
   return (
     <ModalContent isOpen={isOpen} onClose={onClose}>

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -70,7 +70,7 @@ export const Sidebar = () => {
         <div className="flex w-full flex-col items-center">
           <Profile />
           <MenuItem
-            icon={<FaChartSimple className="size-28 p-4" />}
+            icon={<FaChartSimple className="size-28 cursor-pointer p-4" />}
             label="홈"
             onClick={() => {
               close();
@@ -88,7 +88,7 @@ export const Sidebar = () => {
           />
           <GoalList goals={goals} />
           <MenuItem
-            icon={<FaListUl className="size-28 p-4" />}
+            icon={<FaListUl className="size-28 cursor-pointer p-4" />}
             label="내 할일"
             addButton={
               <SidebarButton
@@ -107,7 +107,10 @@ export const Sidebar = () => {
               router.push('/todos');
             }}
           />
-          <MenuItem icon={<FaFire className="size-28 p-4" />} label="팔로워" />
+          <MenuItem
+            icon={<FaFire className="size-28 cursor-pointer p-4" />}
+            label="팔로워"
+          />
         </div>
       )}
       <div className={backGroundClass} onClick={close} />

--- a/src/components/Todos/TodoContainer.tsx
+++ b/src/components/Todos/TodoContainer.tsx
@@ -4,25 +4,30 @@ import { useState } from 'react';
 import { Filter } from '@/components/common/Filter';
 import { TodoList } from '@/components/Todos';
 import { useFilteredTodos } from '@/hooks/useFilteredTodos';
-import { todos, goalFilters, sortFilters } from '@/mocks/todoData';
+import { useTodayTodoQuery } from '@/hooks/apis/Todo/useTodayTodo';
+import { sortFilters } from '@/constants/Todos/TodoFilter';
 
 export const TodoContainer = () => {
-  const [currentSortFilter, setCurrentSortFilter] = useState<string>('최신순');
-  const [currentGoalFilter, setCurrentGoalFilter] = useState<string>('전체');
+  const { todayTodos, isLoading, isError, error } = useTodayTodoQuery();
+
+  const [currentSortFilter, setCurrentSortFilter] = useState<string>('전체');
 
   const handleSortFilterChange = (filter: string) => {
     setCurrentSortFilter(filter);
   };
 
-  const handleGoalFilterChange = (filter: string) => {
-    setCurrentGoalFilter(filter);
-  };
-
   const { inProgressTodos, completedTodos } = useFilteredTodos(
-    todos,
-    currentGoalFilter,
+    todayTodos,
     currentSortFilter,
   );
+
+  if (isLoading) {
+    return <div>불러오는 중...</div>;
+  }
+
+  if (isError) {
+    return <div>에러 발생: {error?.message}</div>;
+  }
 
   return (
     <div className="flex h-screen w-screen flex-col gap-16 bg-custom-white-100 px-16 pt-48">
@@ -30,11 +35,6 @@ export const TodoContainer = () => {
       <Filter
         filters={sortFilters}
         onFilterChange={handleSortFilterChange}
-        className="space-x-8"
-      />
-      <Filter
-        filters={goalFilters}
-        onFilterChange={handleGoalFilterChange}
         className="space-x-8"
       />
       <TodoList

--- a/src/components/Todos/TodoItem.tsx
+++ b/src/components/Todos/TodoItem.tsx
@@ -1,27 +1,65 @@
-import { FaCamera } from 'react-icons/fa6';
+// components/Todos/TodoItem.tsx
 
-interface TodoItemProps {
-  title: string;
-  goal: string;
+'use client';
+
+import { useState } from 'react';
+import { FaCamera } from 'react-icons/fa6';
+import Image from 'next/image';
+import { TodayTodoItem } from '@/hooks/apis/Todo/useTodayTodo';
+import { InputModalContent } from '../ImageInput';
+
+interface TodoItemProps extends TodayTodoItem {
   className?: string;
-  color?: string;
 }
 
 export const TodoItem = (props: TodoItemProps) => {
-  const { title, goal, color, className = '' } = props;
+  const { todoTitle, complete, className = '' } = props;
+
+  const [isGalleryModalOpen, setIsGalleryModalOpen] = useState(false);
+
+  const handleOpenGalleryModal = () => {
+    setIsGalleryModalOpen(true);
+  };
+
+  const handleCloseGalleryModal = () => {
+    setIsGalleryModalOpen(false);
+  };
 
   return (
-    <div className={`flex h-72 ${className}`}>
-      <div
-        className="flex-center my-8 size-56 rounded-16 bg-sub-purple"
-        style={{ backgroundColor: color }}
-      >
-        <FaCamera fill="white" />
+    <>
+      <div className={`flex h-72 ${className}`}>
+        {complete.completePic ? (
+          <div className="flex-center my-8 size-56 overflow-hidden rounded-16 bg-sub-purple">
+            <Image
+              src={complete.completePic}
+              alt="Complete Picture"
+              width={56}
+              height={56}
+              className="object-cover"
+            />
+          </div>
+        ) : (
+          <div
+            className="flex-center my-8 size-56 cursor-pointer rounded-16 bg-sub-purple"
+            onClick={handleOpenGalleryModal}
+          >
+            <FaCamera fill="white" />
+          </div>
+        )}
+        <div className="my-14 ml-16">
+          <div className="text-xs-medium text-custom-gray-100">
+            현재 목표가 안 나와요 ㅠ
+          </div>
+          <div className="text-base-medium text-custom-gray-300">
+            {todoTitle}
+          </div>
+        </div>
       </div>
-      <div className="my-14 ml-16">
-        <div className="text-xs-medium text-custom-gray-100">{goal}</div>
-        <div className="text-base-medium text-custom-gray-300">{title}</div>
-      </div>
-    </div>
+
+      <InputModalContent
+        isOpen={isGalleryModalOpen}
+        onClose={handleCloseGalleryModal}
+      />
+    </>
   );
 };

--- a/src/components/Todos/TodoItem.tsx
+++ b/src/components/Todos/TodoItem.tsx
@@ -28,7 +28,7 @@ export const TodoItem = (props: TodoItemProps) => {
 
   const handleOpenGalleryModal = () => {
     if (complete.completeId) {
-      setCompleteId(complete.completeId); // completeId 설정
+      setCompleteId(complete.completeId);
     }
     setIsGalleryModalOpen(true);
   };
@@ -40,20 +40,16 @@ export const TodoItem = (props: TodoItemProps) => {
   const handleImageSelected = (imageUrl: string) => {
     console.log('Image selected:', imageUrl);
 
-    // 스토어에 이미지 URL 설정
     setImageUrl(imageUrl);
 
-    // completePicName 설정 (completeId가 있어야 함)
     if (complete.completeId) {
       setCompletePicName(`${complete.completeId}-image`);
     }
 
     setCompleteLink('임시링크');
 
-    // 갤러리 모달 닫기
     setIsGalleryModalOpen(false);
 
-    // 인증 모달 열기
     setIsCertifiedModalOpen(true);
   };
 
@@ -61,7 +57,6 @@ export const TodoItem = (props: TodoItemProps) => {
     console.log('Certified Modal closed');
     setIsCertifiedModalOpen(false);
 
-    // 인증 모달을 닫을 때 스토어 초기화
     reset();
   };
 
@@ -88,7 +83,8 @@ export const TodoItem = (props: TodoItemProps) => {
         )}
         <div className="my-14 ml-16">
           <div className="text-xs-medium text-custom-gray-100">
-            현재 목표가 안 나와요 ㅠ
+            현재 목표가 안 나와요 ㅠ(목표 api 수정된걸로 적용해야 하는데 서버
+            터져서 확인 못 하는 중)
           </div>
           <div className="text-base-medium text-custom-gray-300">
             {todoTitle}

--- a/src/components/Todos/TodoItem.tsx
+++ b/src/components/Todos/TodoItem.tsx
@@ -1,5 +1,3 @@
-// components/Todos/TodoItem.tsx
-
 'use client';
 
 import { useState } from 'react';
@@ -7,6 +5,8 @@ import { FaCamera } from 'react-icons/fa6';
 import Image from 'next/image';
 import { TodayTodoItem } from '@/hooks/apis/Todo/useTodayTodo';
 import { InputModalContent } from '../ImageInput';
+import { CertifiedModal } from '../CertifiedModal';
+// Import CertifiedModal
 
 interface TodoItemProps extends TodayTodoItem {
   className?: string;
@@ -16,6 +16,7 @@ export const TodoItem = (props: TodoItemProps) => {
   const { todoTitle, complete, className = '' } = props;
 
   const [isGalleryModalOpen, setIsGalleryModalOpen] = useState(false);
+  const [isCertifiedModalOpen, setIsCertifiedModalOpen] = useState(false); // New state
 
   const handleOpenGalleryModal = () => {
     setIsGalleryModalOpen(true);
@@ -23,6 +24,22 @@ export const TodoItem = (props: TodoItemProps) => {
 
   const handleCloseGalleryModal = () => {
     setIsGalleryModalOpen(false);
+  };
+
+  // Handler for when an image is selected
+  const handleImageSelected = (imageUrl: string) => {
+    // You might want to perform additional actions here, like updating the todo item with the new image
+    console.log('Image selected:', imageUrl);
+
+    // Close the gallery modal
+    setIsGalleryModalOpen(false);
+
+    // Open the certified modal
+    setIsCertifiedModalOpen(true);
+  };
+
+  const handleCloseCertifiedModal = () => {
+    setIsCertifiedModalOpen(false);
   };
 
   return (
@@ -56,9 +73,17 @@ export const TodoItem = (props: TodoItemProps) => {
         </div>
       </div>
 
+      {/* Input Modal */}
       <InputModalContent
         isOpen={isGalleryModalOpen}
         onClose={handleCloseGalleryModal}
+        onImageSelected={handleImageSelected} // Pass the callback
+      />
+
+      {/* Certified Modal */}
+      <CertifiedModal
+        isOpen={isCertifiedModalOpen}
+        onClose={handleCloseCertifiedModal}
       />
     </>
   );

--- a/src/components/Todos/TodoItem.tsx
+++ b/src/components/Todos/TodoItem.tsx
@@ -4,9 +4,9 @@ import { useState } from 'react';
 import { FaCamera } from 'react-icons/fa6';
 import Image from 'next/image';
 import { TodayTodoItem } from '@/hooks/apis/Todo/useTodayTodo';
+import { useVerificationNoteStore } from '@/store/useVerificationNoteStore'; // Zustand 스토어 임포트
 import { InputModalContent } from '../ImageInput';
 import { CertifiedModal } from '../CertifiedModal';
-// Import CertifiedModal
 
 interface TodoItemProps extends TodayTodoItem {
   className?: string;
@@ -16,9 +16,20 @@ export const TodoItem = (props: TodoItemProps) => {
   const { todoTitle, complete, className = '' } = props;
 
   const [isGalleryModalOpen, setIsGalleryModalOpen] = useState(false);
-  const [isCertifiedModalOpen, setIsCertifiedModalOpen] = useState(false); // New state
+  const [isCertifiedModalOpen, setIsCertifiedModalOpen] = useState(false);
+
+  const {
+    setCompleteId,
+    setImageUrl,
+    setCompletePicName,
+    setCompleteLink,
+    reset,
+  } = useVerificationNoteStore();
 
   const handleOpenGalleryModal = () => {
+    if (complete.completeId) {
+      setCompleteId(complete.completeId); // completeId 설정
+    }
     setIsGalleryModalOpen(true);
   };
 
@@ -26,26 +37,38 @@ export const TodoItem = (props: TodoItemProps) => {
     setIsGalleryModalOpen(false);
   };
 
-  // Handler for when an image is selected
   const handleImageSelected = (imageUrl: string) => {
-    // You might want to perform additional actions here, like updating the todo item with the new image
     console.log('Image selected:', imageUrl);
 
-    // Close the gallery modal
+    // 스토어에 이미지 URL 설정
+    setImageUrl(imageUrl);
+
+    // completePicName 설정 (completeId가 있어야 함)
+    if (complete.completeId) {
+      setCompletePicName(`${complete.completeId}-image`);
+    }
+
+    setCompleteLink('임시링크');
+
+    // 갤러리 모달 닫기
     setIsGalleryModalOpen(false);
 
-    // Open the certified modal
+    // 인증 모달 열기
     setIsCertifiedModalOpen(true);
   };
 
   const handleCloseCertifiedModal = () => {
+    console.log('Certified Modal closed');
     setIsCertifiedModalOpen(false);
+
+    // 인증 모달을 닫을 때 스토어 초기화
+    reset();
   };
 
   return (
     <>
       <div className={`flex h-72 ${className}`}>
-        {complete.completePic ? (
+        {complete?.completePic ? (
           <div className="flex-center my-8 size-56 overflow-hidden rounded-16 bg-sub-purple">
             <Image
               src={complete.completePic}
@@ -77,7 +100,7 @@ export const TodoItem = (props: TodoItemProps) => {
       <InputModalContent
         isOpen={isGalleryModalOpen}
         onClose={handleCloseGalleryModal}
-        onImageSelected={handleImageSelected} // Pass the callback
+        onImageSelected={handleImageSelected}
       />
 
       {/* Certified Modal */}

--- a/src/components/Todos/TodoItem.tsx
+++ b/src/components/Todos/TodoItem.tsx
@@ -3,12 +3,20 @@
 import { useState } from 'react';
 import { FaCamera } from 'react-icons/fa6';
 import Image from 'next/image';
-import { TodayTodoItem } from '@/hooks/apis/Todo/useTodayTodo';
+import { TodoCompletesResponse } from '@/hooks/apis/Todo/useTodayTodo';
 import { useVerificationNoteStore } from '@/store/useVerificationNoteStore'; // Zustand 스토어 임포트
 import { InputModalContent } from '../ImageInput';
 import { CertifiedModal } from '../CertifiedModal';
 
-interface TodoItemProps extends TodayTodoItem {
+// interface TodoItemProps extends TodayTodoItem {
+//   className?: string;
+// }
+// api 받아오는 타입이 달라서 잠시 닫아뒀어요
+
+interface TodoItemProps {
+  todoId: number;
+  todoTitle: string;
+  complete?: TodoCompletesResponse;
   className?: string;
 }
 
@@ -27,7 +35,7 @@ export const TodoItem = (props: TodoItemProps) => {
   } = useVerificationNoteStore();
 
   const handleOpenGalleryModal = () => {
-    if (complete.completeId) {
+    if (complete?.completeId) {
       setCompleteId(complete.completeId);
     }
     setIsGalleryModalOpen(true);
@@ -42,7 +50,7 @@ export const TodoItem = (props: TodoItemProps) => {
 
     setImageUrl(imageUrl);
 
-    if (complete.completeId) {
+    if (complete?.completeId) {
       setCompletePicName(`${complete.completeId}-image`);
     }
 

--- a/src/components/Todos/TodoItem.tsx
+++ b/src/components/Todos/TodoItem.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { FaCamera } from 'react-icons/fa6';
 import Image from 'next/image';
 import { TodoCompletesResponse } from '@/hooks/apis/Todo/useTodayTodo';
-import { useVerificationNoteStore } from '@/store/useVerificationNoteStore'; // Zustand 스토어 임포트
+import { useVerificationNoteStore } from '@/store/useVerificationNoteStore';
 import { InputModalContent } from '../ImageInput';
 import { CertifiedModal } from '../CertifiedModal';
 

--- a/src/components/Todos/TodoList.tsx
+++ b/src/components/Todos/TodoList.tsx
@@ -1,10 +1,10 @@
-import { Todo } from '@/types/Todos';
 import { TODO_EMPTY_STATE_MESSAGES } from '@/constants/Todos/TodoMessages';
 import { TodoSection } from '@/components/Todos';
+import { TodayTodoItem } from '@/hooks/apis/Todo/useTodayTodo';
 
 interface TodoListProps {
-  inProgressTodos: Todo[];
-  completedTodos: Todo[];
+  inProgressTodos: TodayTodoItem[];
+  completedTodos: TodayTodoItem[];
 }
 
 export const TodoList = (props: TodoListProps) => {

--- a/src/components/Todos/TodoSection.tsx
+++ b/src/components/Todos/TodoSection.tsx
@@ -1,10 +1,10 @@
 import { FaPlus } from 'react-icons/fa6';
-import { Todo } from '@/types/Todos';
 import { TodoItem } from '@/components/Todos';
+import { TodayTodoItem } from '@/hooks/apis/Todo/useTodayTodo';
 
 interface TodoSectionProps {
   title: string;
-  todos: Todo[];
+  todos: TodayTodoItem[];
   emptyMessage: string;
   showAddButton?: boolean;
 }
@@ -28,7 +28,7 @@ export const TodoSection = (props: TodoSectionProps) => {
             const isLastItem = index === todos.length - 1;
             return (
               <TodoItem
-                key={todo.id}
+                key={todo.todoId}
                 {...todo}
                 className={isLastItem ? '' : 'border-b border-custom-white-200'}
               />

--- a/src/components/VerificationNote/VerificationNoteContainer/index.tsx
+++ b/src/components/VerificationNote/VerificationNoteContainer/index.tsx
@@ -10,7 +10,7 @@ import {
 
 interface VerificationNoteProps {
   onClose: () => void;
-  onSubmit: () => void; // 제출 함수 추가
+  onSubmit: () => void;
 }
 
 export const VerificationNote = ({

--- a/src/components/VerificationNote/VerificationNoteContainer/index.tsx
+++ b/src/components/VerificationNote/VerificationNoteContainer/index.tsx
@@ -8,24 +8,25 @@ import {
   VerificationNoteFile,
 } from '@/components/VerificationNote';
 
-export const VerificationNote = () => {
+interface VerificationNoteProps {
+  onClose: () => void; // onClose prop 추가
+}
+
+export const VerificationNote = ({ onClose }: VerificationNoteProps) => {
   return (
     <div className="flex size-full flex-col gap-24 bg-custom-white-100">
-      {/* 1st content */}
       <div className="flex-center w-full flex-col gap-24 px-16 pt-8">
-        <VerificationNoteHeader />
+        {/* onClose prop을 VerificationNoteHeader에 전달 */}
+        <VerificationNoteHeader onClose={onClose} />
         <VerificationNoteImage />
         <VerificationNoteTextarea />
       </div>
-      {/* 2nd content */}
       <hr className="h-6 w-full bg-custom-white-200" />
-      {/* 3rd content */}
       <div className="flex w-full flex-col gap-24 px-16">
         <VerificationNoteTarget />
         <VerificationNoteTodo />
         <VerificationNoteFile />
       </div>
-      {/* 4th content */}
       <VerificationNoteFooter />
     </div>
   );

--- a/src/components/VerificationNote/VerificationNoteContainer/index.tsx
+++ b/src/components/VerificationNote/VerificationNoteContainer/index.tsx
@@ -9,15 +9,18 @@ import {
 } from '@/components/VerificationNote';
 
 interface VerificationNoteProps {
-  onClose: () => void; // onClose prop 추가
+  onClose: () => void;
+  onSubmit: () => void; // 제출 함수 추가
 }
 
-export const VerificationNote = ({ onClose }: VerificationNoteProps) => {
+export const VerificationNote = ({
+  onClose,
+  onSubmit,
+}: VerificationNoteProps) => {
   return (
     <div className="flex size-full flex-col gap-24 bg-custom-white-100">
       <div className="flex-center w-full flex-col gap-24 px-16 pt-8">
-        {/* onClose prop을 VerificationNoteHeader에 전달 */}
-        <VerificationNoteHeader onClose={onClose} />
+        <VerificationNoteHeader onClose={onClose} onSubmit={onSubmit} />
         <VerificationNoteImage />
         <VerificationNoteTextarea />
       </div>

--- a/src/components/VerificationNote/VerificationNoteFooter/index.tsx
+++ b/src/components/VerificationNote/VerificationNoteFooter/index.tsx
@@ -2,7 +2,7 @@ import { FaLink } from 'react-icons/fa';
 import { useVerificationNoteStore } from '@/store/useVerificationNoteStore';
 
 export const VerificationNoteFooter = () => {
-  const { review } = useVerificationNoteStore();
+  const { note } = useVerificationNoteStore();
 
   return (
     <div className="mt-auto flex w-full items-center justify-between bg-custom-white-200 p-16">
@@ -13,9 +13,9 @@ export const VerificationNoteFooter = () => {
       <div className="flex items-center gap-16">
         <div>
           <span
-            className={`text-xs-medium ${review.length > 100 ? 'text-error' : 'text-custom-gray-300'} `}
+            className={`text-xs-medium ${note.length > 100 ? 'text-error' : 'text-custom-gray-300'} `}
           >
-            {review.length}
+            {note.length}
           </span>
           <span className="text-xs-medium text-custom-gray-300">/100</span>
         </div>

--- a/src/components/VerificationNote/VerificationNoteHeader/index.tsx
+++ b/src/components/VerificationNote/VerificationNoteHeader/index.tsx
@@ -4,7 +4,7 @@ import { useVerificationNoteStore } from '@/store/useVerificationNoteStore';
 
 interface VerificationNoteHeaderProps {
   onClose: () => void;
-  onSubmit: () => void; // 제출 함수 추가
+  onSubmit: () => void;
 }
 
 export const VerificationNoteHeader = ({
@@ -24,7 +24,7 @@ export const VerificationNoteHeader = ({
         size="small"
         radius={false}
         disabled={note.length > 100 ? true : false}
-        onClick={onSubmit} // 제출 함수 연결
+        onClick={onSubmit}
       >
         작성완료
       </Button>

--- a/src/components/VerificationNote/VerificationNoteHeader/index.tsx
+++ b/src/components/VerificationNote/VerificationNoteHeader/index.tsx
@@ -3,18 +3,19 @@ import { Button } from '@/components/common/Button/Button';
 import { useVerificationNoteStore } from '@/store/useVerificationNoteStore';
 
 interface VerificationNoteHeaderProps {
-  onClose: () => void; // onClose prop 추가
+  onClose: () => void;
+  onSubmit: () => void; // 제출 함수 추가
 }
 
 export const VerificationNoteHeader = ({
   onClose,
+  onSubmit,
 }: VerificationNoteHeaderProps) => {
-  const { review } = useVerificationNoteStore();
+  const { note } = useVerificationNoteStore();
 
   return (
     <div className="flex w-full items-center justify-between py-4">
       <div className="flex items-center gap-16">
-        {/* onClick 이벤트에 onClose 함수 연결 */}
         <IoMdClose className="size-24 cursor-pointer" onClick={onClose} />
         <span className="text-xl-semibold">인증</span>
       </div>
@@ -22,7 +23,8 @@ export const VerificationNoteHeader = ({
         className="h-36"
         size="small"
         radius={false}
-        disabled={review.length > 100 ? true : false}
+        disabled={note.length > 100 ? true : false}
+        onClick={onSubmit} // 제출 함수 연결
       >
         작성완료
       </Button>

--- a/src/components/VerificationNote/VerificationNoteHeader/index.tsx
+++ b/src/components/VerificationNote/VerificationNoteHeader/index.tsx
@@ -2,13 +2,20 @@ import { IoMdClose } from 'react-icons/io';
 import { Button } from '@/components/common/Button/Button';
 import { useVerificationNoteStore } from '@/store/useVerificationNoteStore';
 
-export const VerificationNoteHeader = () => {
+interface VerificationNoteHeaderProps {
+  onClose: () => void; // onClose prop 추가
+}
+
+export const VerificationNoteHeader = ({
+  onClose,
+}: VerificationNoteHeaderProps) => {
   const { review } = useVerificationNoteStore();
 
   return (
     <div className="flex w-full items-center justify-between py-4">
       <div className="flex items-center gap-16">
-        <IoMdClose className="size-24 cursor-pointer" />
+        {/* onClick 이벤트에 onClose 함수 연결 */}
+        <IoMdClose className="size-24 cursor-pointer" onClick={onClose} />
         <span className="text-xl-semibold">인증</span>
       </div>
       <Button

--- a/src/components/VerificationNote/VerificationNoteImage/index.tsx
+++ b/src/components/VerificationNote/VerificationNoteImage/index.tsx
@@ -1,10 +1,38 @@
+'use client';
+
 import { IoReload } from 'react-icons/io5';
+import Image from 'next/image';
+import { useVerificationNoteStore } from '@/store/useVerificationNoteStore';
 
 export const VerificationNoteImage = () => {
+  const { imageUrl, setImageUrl, setCompletePicName } =
+    useVerificationNoteStore();
+
+  const handleReload = () => {
+    // 이미지 재촬영 로직을 구현하거나, 갤러리 모달을 다시 여는 로직을 추가할 수 있습니다.
+    // 예를 들어, 갤러리 모달을 다시 열려면:
+    // openGalleryModal(); // 이 함수는 상위 컴포넌트에서 전달받아야 할 수 있습니다.
+    // 여기서는 단순히 이미지 URL과 이름을 초기화합니다.
+    setImageUrl('');
+    setCompletePicName('');
+  };
+
+  if (!imageUrl) {
+    return null;
+  }
+
   return (
     <div className="relative flex size-240">
-      <div className="size-full rounded-16 bg-fuchsia-400" />
-      <button className="flex-center absolute bottom-8 right-8 cursor-pointer gap-4 rounded-170 bg-white px-10 py-6 text-sm-semibold text-primary-200 hover:bg-custom-white-200">
+      <Image
+        src={imageUrl}
+        alt="Selected Image"
+        className="size-full rounded-16 object-cover"
+        fill
+      />
+      <button
+        className="flex-center absolute bottom-8 right-8 cursor-pointer gap-4 rounded-full bg-white px-10 py-2 text-sm-semibold text-primary-200 hover:bg-custom-white-200"
+        onClick={handleReload}
+      >
         <IoReload />
         <span>재촬영</span>
       </button>

--- a/src/components/VerificationNote/VerificationNoteImage/index.tsx
+++ b/src/components/VerificationNote/VerificationNoteImage/index.tsx
@@ -9,10 +9,7 @@ export const VerificationNoteImage = () => {
     useVerificationNoteStore();
 
   const handleReload = () => {
-    // 이미지 재촬영 로직을 구현하거나, 갤러리 모달을 다시 여는 로직을 추가할 수 있습니다.
-    // 예를 들어, 갤러리 모달을 다시 열려면:
-    // openGalleryModal(); // 이 함수는 상위 컴포넌트에서 전달받아야 할 수 있습니다.
-    // 여기서는 단순히 이미지 URL과 이름을 초기화합니다.
+    // 이미지 재촬영 로직 구현 예정
     setImageUrl('');
     setCompletePicName('');
   };

--- a/src/components/VerificationNote/VerificationNoteTextarea/index.tsx
+++ b/src/components/VerificationNote/VerificationNoteTextarea/index.tsx
@@ -2,12 +2,12 @@ import { ChangeEvent, useRef } from 'react';
 import { useVerificationNoteStore } from '@/store/useVerificationNoteStore';
 
 export const VerificationNoteTextarea = () => {
-  const { review, setReview } = useVerificationNoteStore();
+  const { note, setNote } = useVerificationNoteStore();
 
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
 
   const handleTextarea = (e: ChangeEvent<HTMLTextAreaElement>) => {
-    setReview(e.target.value);
+    setNote(e.target.value);
 
     if (textareaRef.current) {
       textareaRef.current.style.height = 'auto';
@@ -20,7 +20,7 @@ export const VerificationNoteTextarea = () => {
       className="h-20 w-full resize-none bg-custom-white-100 text-sm-normal outline-none scrollbar-hide"
       placeholder="이 할 일은 어땠나요?"
       rows={1}
-      value={review}
+      value={note}
       ref={textareaRef}
       onChange={handleTextarea}
     />

--- a/src/constants/ApiEndpoints.ts
+++ b/src/constants/ApiEndpoints.ts
@@ -8,6 +8,8 @@ export const API_ENDPOINTS = {
       `/api/v1/todos/goals/${goalId}`,
     GET_TODAY_PROGRESS: '/api/v1/todos/progress',
     GET_TODAY_TODOS: '/api/v1/todos/today',
+    PUT_CERTIFIED_TODO: (completeId: number) =>
+      `/api/v1/completes/${completeId}`,
   },
   AUTH: {
     SIGN_IN: '/api/v1/auths/login',

--- a/src/constants/QueryKeys.ts
+++ b/src/constants/QueryKeys.ts
@@ -4,4 +4,5 @@ export const QUERY_KEYS = {
   TODAY_PROGRESS: 'todayProgress',
   RECENT_TODOS: 'recentTodos',
   USER_INFO: 'userInfo',
+  TODAY_TODO: 'todayTodo',
 };

--- a/src/constants/QueryKeys.ts
+++ b/src/constants/QueryKeys.ts
@@ -5,4 +5,7 @@ export const QUERY_KEYS = {
   RECENT_TODOS: 'recentTodos',
   USER_INFO: 'userInfo',
   TODAY_TODO: 'todayTodo',
+
+  CERTIFIED_TODO: 'certifiedTodo',
+  CERTIFIED_RECENT_TODO: 'certifiedRecentTodo',
 };

--- a/src/constants/Todos/TodoFilter.ts
+++ b/src/constants/Todos/TodoFilter.ts
@@ -1,1 +1,1 @@
-export const sortFilters = ['진행', '완료'];
+export const sortFilters = ['전체', '진행', '완료'];

--- a/src/constants/Todos/TodoFilter.ts
+++ b/src/constants/Todos/TodoFilter.ts
@@ -1,0 +1,1 @@
+export const sortFilters = ['진행', '완료'];

--- a/src/hooks/apis/Todo/useCertifiedTodo.ts
+++ b/src/hooks/apis/Todo/useCertifiedTodo.ts
@@ -1,0 +1,48 @@
+import {
+  useMutation,
+  UseMutationResult,
+  useQueryClient,
+} from '@tanstack/react-query';
+import { AxiosError, AxiosResponse } from 'axios';
+import { notify } from '@/store/useToastStore';
+import { QUERY_KEYS } from '@/constants/QueryKeys';
+import { useTodoModalStore } from '@/store/useTodoModalStore';
+import { certifiedTodo } from '@/apis/Todo/certifiedTodo';
+
+export interface CertifiedTodoRequest {
+  completePicBase64: string;
+  completePicName: string;
+  note: string;
+  completeLink: string;
+}
+
+interface CertifiedTodoProps {
+  completeId: number;
+  data: CertifiedTodoRequest;
+}
+
+export const useCertifiedTodo = (): UseMutationResult<
+  AxiosResponse,
+  AxiosError,
+  CertifiedTodoProps
+> => {
+  const queryClient = useQueryClient();
+  const { close } = useTodoModalStore();
+
+  return useMutation<AxiosResponse, AxiosError, CertifiedTodoProps>({
+    mutationFn: ({ completeId, data }: CertifiedTodoProps) =>
+      certifiedTodo(completeId, data),
+    onSuccess: () => {
+      notify('success', '수정에 성공하였습니다', 3000);
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.CERTIFIED_TODO] });
+      queryClient.invalidateQueries({
+        queryKey: [QUERY_KEYS.CERTIFIED_RECENT_TODO],
+      });
+      close();
+    },
+    onError: (error: AxiosError) => {
+      notify('error', '수정에 실패하였습니다', 3000);
+      console.error('Error creating todo:', error.message);
+    },
+  });
+};

--- a/src/hooks/apis/Todo/useTodayTodo.ts
+++ b/src/hooks/apis/Todo/useTodayTodo.ts
@@ -5,12 +5,21 @@ import { GET } from '@/apis/services/httpMethod';
 import { API_ENDPOINTS } from '@/constants/ApiEndpoints';
 import { QUERY_KEYS } from '@/constants/QueryKeys';
 import { BaseResponse } from '@/types/response';
-import { CompletesResponse } from '../Dashboard/useTodosOfGoalsQuery';
 
-interface TodayTodoItem {
+export interface TodoCompletesResponse {
+  completeId: number;
+  completePic: string;
+  note: string;
+  completeLink: string;
+  completeStatus: string;
+  createdAt: string;
+  startDate: string;
+}
+
+export interface TodayTodoItem {
   todoId: number;
   todoTitle: string;
-  complete: CompletesResponse;
+  complete: TodoCompletesResponse;
 }
 
 interface TodayTodoResponse extends BaseResponse {

--- a/src/hooks/apis/Todo/useTodayTodo.ts
+++ b/src/hooks/apis/Todo/useTodayTodo.ts
@@ -1,0 +1,32 @@
+import { useQuery, UseQueryOptions } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+
+import { GET } from '@/apis/services/httpMethod';
+import { API_ENDPOINTS } from '@/constants/ApiEndpoints';
+import { QUERY_KEYS } from '@/constants/QueryKeys';
+import { BaseResponse } from '@/types/response';
+import { CompletesResponse } from '../Dashboard/useTodosOfGoalsQuery';
+
+interface TodayTodoResponese extends BaseResponse {
+  data: {
+    todoId: number;
+    todoTitle: string;
+    complete: CompletesResponse[];
+  };
+}
+
+export const todayTodoOptions = (): UseQueryOptions<
+  TodayTodoResponese,
+  AxiosError
+> => ({
+  queryKey: [QUERY_KEYS.TODAY_TODO],
+  queryFn: () => GET<TodayTodoResponese>(API_ENDPOINTS.TODOS.GET_TODAY_TODOS),
+});
+
+export const useTodayProgressQuery = () => {
+  const { data, isLoading, isError, error } = useQuery(todayTodoOptions());
+
+  const todayTodos = data?.data.complete ?? [];
+
+  return { todayTodos, isLoading, isError, error };
+};

--- a/src/hooks/apis/Todo/useTodayTodo.ts
+++ b/src/hooks/apis/Todo/useTodayTodo.ts
@@ -7,26 +7,28 @@ import { QUERY_KEYS } from '@/constants/QueryKeys';
 import { BaseResponse } from '@/types/response';
 import { CompletesResponse } from '../Dashboard/useTodosOfGoalsQuery';
 
-interface TodayTodoResponese extends BaseResponse {
-  data: {
-    todoId: number;
-    todoTitle: string;
-    complete: CompletesResponse[];
-  };
+interface TodayTodoItem {
+  todoId: number;
+  todoTitle: string;
+  complete: CompletesResponse;
+}
+
+interface TodayTodoResponse extends BaseResponse {
+  data: TodayTodoItem[];
 }
 
 export const todayTodoOptions = (): UseQueryOptions<
-  TodayTodoResponese,
+  TodayTodoResponse,
   AxiosError
 > => ({
   queryKey: [QUERY_KEYS.TODAY_TODO],
-  queryFn: () => GET<TodayTodoResponese>(API_ENDPOINTS.TODOS.GET_TODAY_TODOS),
+  queryFn: () => GET<TodayTodoResponse>(API_ENDPOINTS.TODOS.GET_TODAY_TODOS),
 });
 
-export const useTodayProgressQuery = () => {
+export const useTodayTodoQuery = () => {
   const { data, isLoading, isError, error } = useQuery(todayTodoOptions());
 
-  const todayTodos = data?.data.complete ?? [];
+  const todayTodos = data?.data ?? [];
 
   return { todayTodos, isLoading, isError, error };
 };

--- a/src/hooks/useFilteredTodos.ts
+++ b/src/hooks/useFilteredTodos.ts
@@ -1,28 +1,18 @@
 import { useMemo } from 'react';
-import { Todo } from '@/types/Todos';
+import { TodayTodoItem } from './apis/Todo/useTodayTodo';
 
 export function useFilteredTodos(
-  todos: Todo[],
-  currentGoalFilter: string,
+  todos: TodayTodoItem[],
   currentSortFilter: string,
 ) {
-  const { inProgressTodos, completedTodos } = useMemo(() => {
-    const filtered = todos.filter((todo) => {
-      if (currentGoalFilter === '전체') return true;
-      return todo.goal === currentGoalFilter;
-    });
-
-    if (currentSortFilter === '최신순') {
-      filtered.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
-    } else if (currentSortFilter === '오래된 순') {
-      filtered.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+  const filteredTodos = useMemo(() => {
+    if (currentSortFilter === '진행') {
+      return todos.filter((todo) => todo.complete.completeStatus === '진행');
+    } else if (currentSortFilter === '완료') {
+      return todos.filter((todo) => todo.complete.completeStatus === '완료');
     }
+    return todos;
+  }, [todos, currentSortFilter]);
 
-    const inProgress = filtered.filter((todo) => todo.status === 'In Progress');
-    const completed = filtered.filter((todo) => todo.status === 'Completed');
-
-    return { inProgressTodos: inProgress, completedTodos: completed };
-  }, [todos, currentGoalFilter, currentSortFilter]);
-
-  return { inProgressTodos, completedTodos };
+  return { filteredTodos };
 }

--- a/src/hooks/useFilteredTodos.ts
+++ b/src/hooks/useFilteredTodos.ts
@@ -1,18 +1,28 @@
 import { useMemo } from 'react';
-import { TodayTodoItem } from './apis/Todo/useTodayTodo';
+import { TodayTodoItem } from '@/hooks/apis/Todo/useTodayTodo';
 
 export function useFilteredTodos(
   todos: TodayTodoItem[],
   currentSortFilter: string,
 ) {
-  const filteredTodos = useMemo(() => {
-    if (currentSortFilter === '진행') {
-      return todos.filter((todo) => todo.complete.completeStatus === '진행');
-    } else if (currentSortFilter === '완료') {
-      return todos.filter((todo) => todo.complete.completeStatus === '완료');
+  const { inProgressTodos, completedTodos } = useMemo(() => {
+    let inProgress: TodayTodoItem[] = [];
+    let completed: TodayTodoItem[] = [];
+
+    if (currentSortFilter === '진행' || currentSortFilter === '전체') {
+      inProgress = todos.filter(
+        (todo) => todo.complete.completeStatus === '진행',
+      );
     }
-    return todos;
+
+    if (currentSortFilter === '완료' || currentSortFilter === '전체') {
+      completed = todos.filter(
+        (todo) => todo.complete.completeStatus === '완료',
+      );
+    }
+
+    return { inProgressTodos: inProgress, completedTodos: completed };
   }, [todos, currentSortFilter]);
 
-  return { filteredTodos };
+  return { inProgressTodos, completedTodos };
 }

--- a/src/store/useVerificationNoteStore.ts
+++ b/src/store/useVerificationNoteStore.ts
@@ -31,7 +31,7 @@ export const useVerificationNoteStore = create<VerificationNoteState>(
         imageUrl: '',
         completePicName: '',
         note: '',
-        completeLink: '임시링크',
+        completeLink: '임시링크', // 지금 회의내용으로는 링크 없애기로 했는데 아직 있어서 잠시 지정 이렇게 해놨어요
         completeId: null,
       }),
   }),

--- a/src/store/useVerificationNoteStore.ts
+++ b/src/store/useVerificationNoteStore.ts
@@ -1,13 +1,38 @@
-import { create } from 'zustand';
+import { create } from 'zustand/react';
 
 interface VerificationNoteState {
-  review: string;
-  setReview: (review: string) => void;
+  imageUrl: string;
+  completePicName: string;
+  note: string;
+  completeLink: string;
+  completeId: number | null;
+  setImageUrl: (url: string) => void;
+  setCompletePicName: (name: string) => void;
+  setNote: (note: string) => void;
+  setCompleteLink: (link: string) => void;
+  setCompleteId: (id: number) => void;
+  reset: () => void;
 }
 
 export const useVerificationNoteStore = create<VerificationNoteState>(
   (set) => ({
-    review: '',
-    setReview: (review: string) => set({ review: review }),
+    imageUrl: '',
+    completePicName: '',
+    note: '',
+    completeLink: '임시링크',
+    completeId: null,
+    setImageUrl: (url) => set({ imageUrl: url }),
+    setCompletePicName: (name) => set({ completePicName: name }),
+    setNote: (note) => set({ note }),
+    setCompleteLink: (link) => set({ completeLink: link }),
+    setCompleteId: (id) => set({ completeId: id }),
+    reset: () =>
+      set({
+        imageUrl: '',
+        completePicName: '',
+        note: '',
+        completeLink: '임시링크',
+        completeId: null,
+      }),
   }),
 );


### PR DESCRIPTION
# 📄 [Feat] 내 할 일 페이지 api 연동 및 인증 로직 구현

## 📝 변경 사항 요약
- 내 할 일 페이지 api 연동
- 인증 로직 구현 및 적용(사진 촬영 및 base64 등등)

## 📌 관련 이슈
- 이슈 번호: #91 

## 🔍 변경 사항 상세 설명
- 인증 관리에 필요한 store 수정(기존 노트 store)
- api 생성 및 해당하는 hook 구현
- type 지정 및 설정

## ✅ 확인 사항
- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 관련 테스트를 작성하고 모두 통과했는지 확인했습니다.
- [x] 코드 스타일 가이드에 맞게 작성했습니다.

# 코드리뷰하기 전에 잠깐!읽어주세요! 😥
아직 구현 안 된 부분이 있습니당 월요일 안에 리팩토링 전부 진행할 예정!

- 대시보드의 todoitem 타입이 다른 점 수정(Api로 보면서 확인해야 하는데 지금 스웨거 확인이 불가능해요)
- 대시보드에서 인증 시 `completeId` 설정이 되지 않는 부분 수정
- notify 에러, 성공 메세지 상수화
- 이미지 재촬영 로직 적용하기(구현은 해놨는데 확인을 못 해요 2)
- 파일 이름 통일하기 (인증 모달은 `CertifiedModal` 인데 안에서 사용하는 컴포넌트는 기범님이 만드신 `VerificationNote...` 이름이라 보는 저도 조금 헷갈려요)
- 파일 안의 로직 분리 및 컴포넌트 분리(한 파일에 코드가 좀 긴 거 같아서 분리할 예정입니다 특히 `TodoItem`)
- isLoading, isError일 때 처리 (isLoading 시에 스켈레톤, error일 때 notify 후 그 전 페이지로 이동으로 생각중입니다)

## 위의 수정사항은 리팩토링 이슈 따로 파서 진행할 예정입니당 빠르게 머지하기가 목표 ㅠ