### PR TITLE
[Feat] 할 일 생성 모달 임시저장 기능 구현

### DIFF
--- a/src/components/ConfirmationModal/index.tsx
+++ b/src/components/ConfirmationModal/index.tsx
@@ -1,0 +1,41 @@
+import { Button } from '../common/Button/Button';
+import { ModalContent } from '../common/Modal';
+
+interface ConfirmationModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  onCancel: () => void;
+  title?: string;
+  description?: string;
+  confirmText?: string;
+  cancelText?: string;
+}
+
+export const ConfirmationModal = (props: ConfirmationModalProps) => {
+  const {
+    isOpen,
+    onClose,
+    onConfirm,
+    onCancel,
+    title = '제목',
+    description = '이 작업을 진행하시겠습니까?',
+    confirmText = '예',
+    cancelText = '아니오',
+  } = props;
+
+  return (
+    <ModalContent isOpen={isOpen} onClose={onClose}>
+      <div className="flex flex-col items-center justify-center px-24">
+        <h1 className="mb-16 text-xl font-bold">{title}</h1>
+
+        <p className="mb-24">{description}</p>
+
+        <div className="flex w-full justify-between">
+          <Button onClick={onConfirm}>{confirmText}</Button>
+          <Button onClick={onCancel}>{cancelText}</Button>
+        </div>
+      </div>
+    </ModalContent>
+  );
+};

--- a/src/components/ConfirmationModal/index.tsx
+++ b/src/components/ConfirmationModal/index.tsx
@@ -31,9 +31,13 @@ export const ConfirmationModal = (props: ConfirmationModalProps) => {
 
         <p className="mb-24">{description}</p>
 
-        <div className="flex w-full justify-between">
-          <Button onClick={onConfirm}>{confirmText}</Button>
-          <Button onClick={onCancel}>{cancelText}</Button>
+        <div className="flex w-full justify-between gap-10">
+          <Button size="medium" className="w-120 px-12" onClick={onConfirm}>
+            {confirmText}
+          </Button>
+          <Button size="medium" className="w-120 px-12" onClick={onCancel}>
+            {cancelText}
+          </Button>
         </div>
       </div>
     </ModalContent>

--- a/src/components/VerificationNote/VerificationNoteFooter/index.tsx
+++ b/src/components/VerificationNote/VerificationNoteFooter/index.tsx
@@ -1,87 +1,21 @@
 'use client';
 
-import { useState, useEffect } from 'react';
 import { FaLink } from 'react-icons/fa';
-
-import { useVerificationNoteStore } from '@/store/useVerificationNoteStore';
 import { ConfirmationModal } from '@/components/ConfirmationModal';
-import { notify } from '@/store/useToastStore';
-import { MODAL_MESSAGES, TOAST_MESSAGES } from '@/constants/Messages';
+import { MODAL_MESSAGES } from '@/constants/Messages';
+import { useVerificationNoteFooter } from '@/hooks/useVerificationNoteFooter';
 
 export const VerificationNoteFooter = () => {
   const {
     note,
-    imageUrl,
-    completePicName,
-    completeLink,
-    completeId,
-    setImageUrl,
-    setCompletePicName,
-    setNote,
-    setCompleteLink,
-    setCompleteId,
-  } = useVerificationNoteStore();
-
-  const [isSaved, setIsSaved] = useState(false);
-  const [isModalOpen, setIsModalOpen] = useState(false);
-  const [confirmationMode, setConfirmationMode] = useState<'save' | 'load'>(
-    'save',
-  );
-
-  useEffect(() => {
-    const savedData = localStorage.getItem('verificationNote');
-    if (savedData) {
-      setIsSaved(true);
-    }
-  }, []);
-
-  const handleClick = () => {
-    if (isSaved) {
-      setConfirmationMode('load');
-    } else {
-      setConfirmationMode('save');
-    }
-    setIsModalOpen(true);
-  };
-
-  const handleCloseModal = () => {
-    setIsModalOpen(false);
-  };
-
-  const handleConfirm = () => {
-    if (confirmationMode === 'save') {
-      const dataToSave = {
-        imageUrl,
-        completePicName,
-        note,
-        completeLink,
-        completeId,
-      };
-      localStorage.setItem('verificationNote', JSON.stringify(dataToSave));
-
-      notify('success', TOAST_MESSAGES.SAVE_SUCCESS, 3000);
-      setIsSaved(true);
-    } else {
-      const savedData = localStorage.getItem('verificationNote');
-      if (savedData) {
-        const parsedData = JSON.parse(savedData);
-        setImageUrl(parsedData.imageUrl);
-        setCompletePicName(parsedData.completePicName);
-        setNote(parsedData.note);
-        setCompleteLink(parsedData.completeLink);
-        setCompleteId(parsedData.completeId);
-
-        localStorage.removeItem('verificationNote');
-        setIsSaved(false);
-        notify('success', TOAST_MESSAGES.LOAD_SUCCESS, 3000);
-      }
-    }
-    setIsModalOpen(false);
-  };
-
-  const handleCancel = () => {
-    setIsModalOpen(false);
-  };
+    isSaved,
+    isModalOpen,
+    confirmationMode,
+    handleClick,
+    handleCloseModal,
+    handleConfirm,
+    handleCancel,
+  } = useVerificationNoteFooter();
 
   return (
     <div className="mt-auto flex w-full items-center justify-between bg-custom-white-200 p-16">

--- a/src/components/VerificationNote/VerificationNoteFooter/index.tsx
+++ b/src/components/VerificationNote/VerificationNoteFooter/index.tsx
@@ -44,6 +44,10 @@ export const VerificationNoteFooter = () => {
           setCompleteLink(parsedData.completeLink);
           setCompleteId(parsedData.completeId);
 
+          // 불러오기를 완료하면 로컬 스토리지에서 삭제
+          localStorage.removeItem('verificationNote');
+          setIsSaved(false);
+
           console.log('임시 저장된 내용이 불러와졌습니다!');
         }
       }
@@ -82,7 +86,6 @@ export const VerificationNoteFooter = () => {
           </span>
           <span className="text-xs-medium text-custom-gray-300">/100</span>
         </div>
-        {/* 여기 span이 클릭 시 임시저장 / 불러오기 로직을 수행 */}
         <span
           className="cursor-pointer text-sm-medium text-primary-100"
           onClick={handleSaveOrLoad}

--- a/src/components/VerificationNote/VerificationNoteFooter/index.tsx
+++ b/src/components/VerificationNote/VerificationNoteFooter/index.tsx
@@ -1,8 +1,69 @@
+'use client';
+
+import { useEffect, useState } from 'react';
 import { FaLink } from 'react-icons/fa';
 import { useVerificationNoteStore } from '@/store/useVerificationNoteStore';
 
 export const VerificationNoteFooter = () => {
-  const { note } = useVerificationNoteStore();
+  const {
+    note,
+    imageUrl,
+    completePicName,
+    completeLink,
+    completeId,
+    setImageUrl,
+    setCompletePicName,
+    setNote,
+    setCompleteLink,
+    setCompleteId,
+  } = useVerificationNoteStore();
+
+  // 로컬 스토리지에 이미 저장된 내용이 있는지 여부
+  const [isSaved, setIsSaved] = useState(false);
+
+  // 컴포넌트 마운트 시점에 한번 확인
+  useEffect(() => {
+    const savedData = localStorage.getItem('verificationNote');
+    if (savedData) {
+      setIsSaved(true);
+    }
+  }, []);
+
+  const handleSaveOrLoad = () => {
+    if (isSaved) {
+      // 이미 저장된 데이터가 있으므로 '불러오기' 로직
+      if (window.confirm('임시 저장된 내용을 불러오시겠습니까?')) {
+        const savedData = localStorage.getItem('verificationNote');
+        if (savedData) {
+          const parsedData = JSON.parse(savedData);
+
+          // store 업데이트
+          setImageUrl(parsedData.imageUrl);
+          setCompletePicName(parsedData.completePicName);
+          setNote(parsedData.note);
+          setCompleteLink(parsedData.completeLink);
+          setCompleteId(parsedData.completeId);
+
+          console.log('임시 저장된 내용이 불러와졌습니다!');
+        }
+      }
+    } else {
+      // 저장된 데이터가 없으므로 '임시저장' 로직
+      if (window.confirm('내용을 임시저장하시겠습니까?')) {
+        const dataToSave = {
+          imageUrl,
+          completePicName,
+          note,
+          completeLink,
+          completeId,
+        };
+
+        localStorage.setItem('verificationNote', JSON.stringify(dataToSave));
+        console.log('임시 저장 되었습니다!');
+        setIsSaved(true); // 이제 저장된 상태로 표시
+      }
+    }
+  };
 
   return (
     <div className="mt-auto flex w-full items-center justify-between bg-custom-white-200 p-16">
@@ -13,13 +74,21 @@ export const VerificationNoteFooter = () => {
       <div className="flex items-center gap-16">
         <div>
           <span
-            className={`text-xs-medium ${note.length > 100 ? 'text-error' : 'text-custom-gray-300'} `}
+            className={`text-xs-medium ${
+              note.length > 100 ? 'text-error' : 'text-custom-gray-300'
+            } `}
           >
             {note.length}
           </span>
           <span className="text-xs-medium text-custom-gray-300">/100</span>
         </div>
-        <span className="text-sm-medium text-primary-100">임시저장</span>
+        {/* 여기 span이 클릭 시 임시저장 / 불러오기 로직을 수행 */}
+        <span
+          className="cursor-pointer text-sm-medium text-primary-100"
+          onClick={handleSaveOrLoad}
+        >
+          {isSaved ? '불러오기' : '임시저장'}
+        </span>
       </div>
     </div>
   );

--- a/src/constants/Messages.ts
+++ b/src/constants/Messages.ts
@@ -1,0 +1,15 @@
+export const ERROR_MESSAGE = 'Toast 메시지는 비어있을 수 없습니다.';
+
+export const TOAST_MESSAGES = {
+  SAVE_SUCCESS: '임시 저장 되었습니다.',
+  LOAD_SUCCESS: '불러오기가 완료되었습니다.',
+};
+
+export const MODAL_MESSAGES = {
+  SAVE_TITLE: '임시저장',
+  LOAD_TITLE: '불러오기',
+  SAVE_CONFIRM_DESCRIPTION: '작성된 내용을 임시 저장하시겠습니까?',
+  LOAD_CONFIRM_DESCRIPTION: '임시 저장된 내용을 불러오시겠습니까?',
+  CONFIRM_TEXT: '예',
+  CANCEL_TEXT: '아니오',
+};

--- a/src/constants/ToastMessages.ts
+++ b/src/constants/ToastMessages.ts
@@ -1,1 +1,0 @@
-export const ERROR_MESSAGE = 'Toast 메시지는 비어있을 수 없습니다.';

--- a/src/constants/keys.ts
+++ b/src/constants/keys.ts
@@ -1,0 +1,3 @@
+export const LOCAL_STORAGE_KEYS = {
+  VERIFICATION_NOTE: 'verificationNote',
+};

--- a/src/hooks/useVerificationNoteFooter.ts
+++ b/src/hooks/useVerificationNoteFooter.ts
@@ -1,0 +1,96 @@
+import { useState, useEffect } from 'react';
+import { useVerificationNoteStore } from '@/store/useVerificationNoteStore';
+import { notify } from '@/store/useToastStore';
+import { TOAST_MESSAGES } from '@/constants/Messages';
+import { LOCAL_STORAGE_KEYS } from '@/constants/keys';
+
+type ConfirmationMode = 'save' | 'load';
+
+export const useVerificationNoteFooter = () => {
+  const {
+    note,
+    imageUrl,
+    completePicName,
+    completeLink,
+    completeId,
+    setImageUrl,
+    setCompletePicName,
+    setNote,
+    setCompleteLink,
+    setCompleteId,
+  } = useVerificationNoteStore();
+
+  const [isSaved, setIsSaved] = useState(false);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [confirmationMode, setConfirmationMode] =
+    useState<ConfirmationMode>('save');
+
+  useEffect(() => {
+    const savedData = localStorage.getItem(
+      LOCAL_STORAGE_KEYS.VERIFICATION_NOTE,
+    );
+    if (savedData) {
+      setIsSaved(true);
+    }
+  }, []);
+
+  const handleClick = () => {
+    setConfirmationMode(isSaved ? 'load' : 'save');
+    setIsModalOpen(true);
+  };
+
+  const handleCloseModal = () => {
+    setIsModalOpen(false);
+  };
+
+  const handleConfirm = () => {
+    if (confirmationMode === 'save') {
+      const dataToSave = {
+        imageUrl,
+        completePicName,
+        note,
+        completeLink,
+        completeId,
+      };
+      localStorage.setItem(
+        LOCAL_STORAGE_KEYS.VERIFICATION_NOTE,
+        JSON.stringify(dataToSave),
+      );
+
+      notify('success', TOAST_MESSAGES.SAVE_SUCCESS, 3000);
+      setIsSaved(true);
+    } else {
+      const savedData = localStorage.getItem(
+        LOCAL_STORAGE_KEYS.VERIFICATION_NOTE,
+      );
+      if (savedData) {
+        const parsedData = JSON.parse(savedData);
+        setImageUrl(parsedData.imageUrl);
+        setCompletePicName(parsedData.completePicName);
+        setNote(parsedData.note);
+        setCompleteLink(parsedData.completeLink);
+        setCompleteId(parsedData.completeId);
+
+        localStorage.removeItem(LOCAL_STORAGE_KEYS.VERIFICATION_NOTE);
+        setIsSaved(false);
+        notify('success', TOAST_MESSAGES.LOAD_SUCCESS, 3000);
+      }
+    }
+    setIsModalOpen(false);
+  };
+
+  const handleCancel = () => {
+    setIsModalOpen(false);
+  };
+
+  return {
+    note,
+    isSaved,
+    isModalOpen,
+    confirmationMode,
+    handleClick,
+    handleCloseModal,
+    handleConfirm,
+    handleCancel,
+  };
+};

--- a/src/store/useToastStore.ts
+++ b/src/store/useToastStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { ERROR_MESSAGE } from '@/constants/ToastMessages';
+import { ERROR_MESSAGE } from '@/constants/Messages';
 
 interface ToastState {
   type: 'success' | 'error' | 'info' | null;


### PR DESCRIPTION
# 📄 [Feat] 할 일 생성 모달 임시저장 기능 구현

## 📝 변경 사항 요약
- 로컬스토리지를 통한 임시저장 기능 구현
- 예, 아니오 등의 확인에 사용되는 모달 `ConfirmationModal` 구현

## 📌 관련 이슈
- 이슈 번호: #90 

## 🔍 변경 사항 상세 설명
- 로컬 스토리지를 통해 임시저장 구현했습니다
- 모달이 따로 필요해서 하나 만들어놨어요 이게 가장 범용적으로 사용될 수 있는 모달일 듯?
- 상수화를 따로 좀 빼놨는데 이런 관리가 괜찮으시다면 다른 부분을 최대한 다 빼둘 생각이에요

## ✅ 확인 사항
- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 관련 테스트를 작성하고 모두 통과했는지 확인했습니다.
- [x] 코드 스타일 가이드에 맞게 작성했습니다.

## 📸 스크린샷 (선택 사항)

https://github.com/user-attachments/assets/cbe639d5-8305-47e2-a652-ac39d9e9f3c1

## 기타 참고 사항
여기 분량이 좀 따로 나눠야 하는 부분인 거 같아서 짤라서 미리 올렸어요

근데 님들 중요한 부분이 있음 제가 기억이 잘 안 나는 거 같은데

임시저장을 할 때 작성하고 있던 목표와 할 일도 같이 저장이 되는건가요? 만약 저장된다고 하면 나중에 해당 목표나 할 일이 삭제되었을 때 관련 로직을 또 추가해서 임시저장 자체를 날려버리거나 하는 걸로 구분이 필요함...

만약 저장이 되지 않는다고 하면 임시저장을 할 때 미리 모달에다가 알려주기만 하면 되는 거라 간단해지긴 해요 어떤 게 나을까요

목표랑 할 일은 드롭다운으로 나와야 하는데 다른 곳에서 작업하고 있는 거라 아직 적용 덜 됐어용 ㅎ.ㅎ

머지하고 다른 쪽에서 적용하고 손보고 PR 또 올릴게여