### PR TITLE
[Feat] 타인 프로필 페이지 제작

### DIFF
--- a/src/app/(route)/search/page.tsx
+++ b/src/app/(route)/search/page.tsx
@@ -4,7 +4,7 @@ import { SearchInput } from '@/components/Search/SearchInput';
 
 export default function SearchPage() {
   return (
-    <div className="flex min-h-screen w-screen flex-col gap-16 bg-custom-white-100 p-16">
+    <div className="flex min-h-screen w-screen flex-col gap-16 bg-custom-white-100 p-16 md:px-200 xl:px-400 2xl:px-650">
       <SearchHeader />
       <SearchInput />
       <SearchContent />

--- a/src/app/(route)/userProfile/[userId]/layout.tsx
+++ b/src/app/(route)/userProfile/[userId]/layout.tsx
@@ -1,8 +1,8 @@
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
-  title: 'Search Users or Goals',
-  description: 'Search Page',
+  title: 'User Profile',
+  description: 'User Profile Page',
 };
 
 export default function RootLayout({

--- a/src/app/(route)/userProfile/[userId]/page.tsx
+++ b/src/app/(route)/userProfile/[userId]/page.tsx
@@ -1,0 +1,19 @@
+import { UserProfileContent } from '@/components/UserProfile/UserProfileContent';
+import { UserProfileHeader } from '@/components/UserProfile/UserProfileHeader';
+
+interface UserProfileProps {
+  params: {
+    userId: string;
+  };
+}
+
+export default async function userProfile({ params }: UserProfileProps) {
+  const { userId } = await params;
+
+  return (
+    <div className="flex min-h-screen w-screen flex-col gap-16 bg-custom-white-100 p-16">
+      <UserProfileHeader userId={userId} />
+      <UserProfileContent />
+    </div>
+  );
+}

--- a/src/app/(route)/userProfile/[userId]/page.tsx
+++ b/src/app/(route)/userProfile/[userId]/page.tsx
@@ -11,7 +11,7 @@ export default async function userProfile({ params }: UserProfileProps) {
   const { userId } = await params;
 
   return (
-    <div className="flex min-h-screen w-screen flex-col gap-16 bg-custom-white-100 p-16">
+    <div className="flex min-h-screen w-screen flex-col gap-16 bg-custom-white-100 p-16 md:px-200 xl:px-400 2xl:px-650">
       <UserProfileHeader userId={userId} />
       <UserProfileContent />
     </div>

--- a/src/components/UserProfile/UserProfileContent/index.tsx
+++ b/src/components/UserProfile/UserProfileContent/index.tsx
@@ -1,0 +1,25 @@
+import Image from 'next/image';
+
+export const UserProfileContent = () => {
+  const images = Array.from({ length: 10 }, (_, index) => ({
+    id: index,
+    src: 'https://slid-todo.s3.ap-northeast-2.amazonaws.com/a19c4793-d33b-4be6-9f65-097bed5a6709_testmouse1.png',
+    alt: `프로필 사진 ${index + 1}`,
+  }));
+
+  return (
+    <div className="mt-8 grid grid-cols-3 gap-8">
+      {images.map((image) => (
+        <Image
+          key={image.id}
+          width={48}
+          height={48}
+          className="flex h-109 w-full rounded-4"
+          priority
+          src={image.src}
+          alt={image.alt}
+        />
+      ))}
+    </div>
+  );
+};

--- a/src/components/UserProfile/UserProfileHeader/index.tsx
+++ b/src/components/UserProfile/UserProfileHeader/index.tsx
@@ -1,0 +1,31 @@
+import { IoMdClose } from 'react-icons/io';
+import Image from 'next/image';
+import { Button } from '@/components/common/Button/Button';
+
+interface UserProfileHeader {
+  userId: string;
+}
+
+export const UserProfileHeader = ({ userId }: UserProfileHeader) => {
+  return (
+    <>
+      <IoMdClose className="size-24 cursor-pointer" />
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-8">
+          <Image
+            width={48}
+            height={48}
+            className="flex size-64 rounded-full"
+            priority
+            src="https://slid-todo.s3.ap-northeast-2.amazonaws.com/a19c4793-d33b-4be6-9f65-097bed5a6709_testmouse1.png"
+            alt="프로필 사진"
+          />
+          <span className="text-base-medium">체다치즈 {userId}</span>
+        </div>
+        <Button size="small" primary={false}>
+          팔로우
+        </Button>
+      </div>
+    </>
+  );
+};

--- a/src/components/UserProfile/UserProfileHeader/index.tsx
+++ b/src/components/UserProfile/UserProfileHeader/index.tsx
@@ -1,4 +1,7 @@
+'use client';
+
 import { IoMdClose } from 'react-icons/io';
+import { useRouter } from 'next/navigation';
 import Image from 'next/image';
 import { Button } from '@/components/common/Button/Button';
 
@@ -7,9 +10,15 @@ interface UserProfileHeader {
 }
 
 export const UserProfileHeader = ({ userId }: UserProfileHeader) => {
+  const router = useRouter();
+
+  const handleBack = () => {
+    router.back();
+  };
+
   return (
     <>
-      <IoMdClose className="size-24 cursor-pointer" />
+      <IoMdClose className="size-24 cursor-pointer" onClick={handleBack} />
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-8">
           <Image


### PR DESCRIPTION
# 📄 타인 프로필 페이지 제작

## 📝 변경 사항 요약
- 타인 프로필 페이지 퍼블리싱
- 동적 라우팅

## 📌 관련 이슈
- 이슈 번호: #143 

## 🔍 변경 사항 상세 설명
동적 라우팅 사용으로 검색 페이지 혹은 팔로워 페이지에서 해당 유저의 프로필을 클릭하면
userProfile/[userId]로 이동하도록 하였음.

## ✅ 확인 사항
- [ ] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [ ] 관련 테스트를 작성하고 모두 통과했는지 확인했습니다.
- [ ] 코드 스타일 가이드에 맞게 작성했습니다.

## 📸 스크린샷 (선택 사항)
동적 라우팅 사용
![image](https://github.com/user-attachments/assets/24decae4-bc84-48f3-9085-e4078b60b51f)
![image](https://github.com/user-attachments/assets/61ce2060-0e8a-4012-8891-860ff7e0f620)


## 기타 참고 사항
추가로 공유하고 싶은 내용이나 참고 자료가 있다면 여기에 작성해주세요.
