### PR TITLE
[Feat] add picture in dashboard

### DIFF
--- a/__test__/formatDateToRelativeTime.spec.ts
+++ b/__test__/formatDateToRelativeTime.spec.ts
@@ -4,11 +4,12 @@ describe('formatDateToRelativeTime 테스트', () => {
   const fixedDate = new Date('2024-12-23T00:00:00Z').getTime();
 
   beforeAll(() => {
-    jest.spyOn(Date, 'now').mockReturnValue(fixedDate);
+    jest.useFakeTimers();
+    jest.setSystemTime(fixedDate);
   });
 
   afterAll(() => {
-    jest.restoreAllMocks();
+    jest.useRealTimers();
   });
 
   it('현재 날짜와 동일한 시간', () => {

--- a/__test__/isDatePast.spec.ts
+++ b/__test__/isDatePast.spec.ts
@@ -1,0 +1,34 @@
+import { isDatePast } from '@/utils/date';
+
+describe('isDatePast 테스트', () => {
+  const fixedDate = new Date('2024-12-20T00:00:00Z');
+
+  beforeAll(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(fixedDate);
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  it('과거 날짜인 경우', () => {
+    const date = '2024-12-19';
+    expect(isDatePast(date)).toBe(true);
+  });
+
+  it('오늘 날짜인 경우', () => {
+    const date = '2024-12-20';
+    expect(isDatePast(date)).toBe(false);
+  });
+
+  it('미래 날짜인 경우', () => {
+    const date = '2024-12-21';
+    expect(isDatePast(date)).toBe(false);
+  });
+
+  it('빈 문자열 처리', () => {
+    const date = '';
+    expect(isDatePast(date)).toBe(false);
+  });
+});

--- a/src/components/Dashboard/GoalList/GoalItem/ProgressLine/index.tsx
+++ b/src/components/Dashboard/GoalList/GoalItem/ProgressLine/index.tsx
@@ -9,11 +9,11 @@ export const ProgressLine = ({ percent, color }: ProgressLineProps) => {
       <div className="h-12 w-full rounded-full bg-custom-white-200">
         <div
           className="h-12 rounded-full"
-          style={{ width: `${percent}%`, backgroundColor: color }}
+          style={{ width: `${Math.floor(percent)}%`, backgroundColor: color }}
         />
       </div>
       <p className="text-sm-semibold" style={{ color: color }}>
-        {percent}%
+        {Math.floor(percent).toLocaleString()}%
       </p>
     </div>
   );

--- a/src/components/Dashboard/GoalList/GoalItem/TodoList/TodoPic/index.tsx
+++ b/src/components/Dashboard/GoalList/GoalItem/TodoList/TodoPic/index.tsx
@@ -3,20 +3,32 @@ import { useState } from 'react';
 import Image from 'next/image';
 
 import { Skeleton } from '@/components/common/Skeleton';
+import { cn } from '@/utils/className';
 
 interface TodoItemProps {
   index: number;
   color: string;
   pic: string;
+  status: string;
+  date: string;
 }
 
-export const TodoPic = ({ index, color, pic }: TodoItemProps) => {
+export const TodoPic = ({ index, color, pic, status, date }: TodoItemProps) => {
   const [isLoaded, setIsLoaded] = useState(pic === '' || false);
+  const today = new Date().setHours(0, 0, 0, 0);
+  const thisDay = new Date(date).setHours(0, 0, 0, 0);
+  const isPast = today > thisDay;
+  const backgroundColor =
+    status === '인증' ? color : isPast ? '#E9E9E9' : color;
+  const textClass = cn(
+    'z-10 !text-base-medium',
+    isPast && 'text-custom-gray-100',
+  );
 
   return (
     <div
       className="flex-center relative aspect-square rounded-16"
-      style={{ backgroundColor: color }}
+      style={{ backgroundColor: backgroundColor }}
     >
       {!isLoaded && pic && (
         <Skeleton className="absolute inset-0 size-full rounded-16" />
@@ -27,10 +39,10 @@ export const TodoPic = ({ index, color, pic }: TodoItemProps) => {
           fill
           alt="인증 사진"
           onLoad={() => setIsLoaded(true)}
-          className="rounded-16 object-cover"
+          className="rounded-16 object-cover opacity-50"
         />
       )}
-      {index + 1}
+      <span className={textClass}>{index + 1}</span>
     </div>
   );
 };

--- a/src/components/Dashboard/GoalList/GoalItem/TodoList/TodoPic/index.tsx
+++ b/src/components/Dashboard/GoalList/GoalItem/TodoList/TodoPic/index.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image';
 
 import { Skeleton } from '@/components/common/Skeleton';
 import { cn } from '@/utils/className';
+import { isDatePast } from '@/utils/date';
 
 interface TodoItemProps {
   index: number;
@@ -15,9 +16,7 @@ interface TodoItemProps {
 
 export const TodoPic = ({ index, color, pic, status, date }: TodoItemProps) => {
   const [isLoaded, setIsLoaded] = useState(pic === '' || false);
-  const today = new Date().setHours(0, 0, 0, 0);
-  const thisDay = new Date(date).setHours(0, 0, 0, 0);
-  const isPast = today > thisDay;
+  const isPast = isDatePast(date);
   const backgroundColor =
     status === '인증' ? color : isPast ? '#E9E9E9' : color;
   const textClass = cn(

--- a/src/components/Dashboard/GoalList/GoalItem/TodoList/TodoPic/index.tsx
+++ b/src/components/Dashboard/GoalList/GoalItem/TodoList/TodoPic/index.tsx
@@ -1,14 +1,35 @@
+import { useState } from 'react';
+
+import Image from 'next/image';
+
+import { Skeleton } from '@/components/common/Skeleton';
+
 interface TodoItemProps {
   index: number;
   color: string;
+  pic: string;
 }
 
-export const TodoPic = ({ index, color }: TodoItemProps) => {
+export const TodoPic = ({ index, color, pic }: TodoItemProps) => {
+  const [isLoaded, setIsLoaded] = useState(pic === '' || false);
+
   return (
     <div
-      className="flex-center aspect-square rounded-16"
+      className="flex-center relative aspect-square rounded-16"
       style={{ backgroundColor: color }}
     >
+      {!isLoaded && pic && (
+        <Skeleton className="absolute inset-0 size-full rounded-16" />
+      )}
+      {pic && (
+        <Image
+          src={pic}
+          fill
+          alt="인증 사진"
+          onLoad={() => setIsLoaded(true)}
+          className="rounded-16 object-cover"
+        />
+      )}
       {index + 1}
     </div>
   );

--- a/src/components/Dashboard/GoalList/GoalItem/TodoList/TodoPic/index.tsx
+++ b/src/components/Dashboard/GoalList/GoalItem/TodoList/TodoPic/index.tsx
@@ -20,8 +20,8 @@ export const TodoPic = ({ index, color, pic, status, date }: TodoItemProps) => {
   const backgroundColor =
     status === '인증' ? color : isPast ? '#E9E9E9' : color;
   const textClass = cn(
-    'z-10 !text-base-medium',
-    isPast && 'text-custom-gray-100',
+    'absolute inset-0 flex-center !text-base-medium',
+    isPast ? 'text-custom-gray-100' : 'text-custom-gray-300',
   );
 
   return (

--- a/src/components/Dashboard/GoalList/GoalItem/TodoList/index.tsx
+++ b/src/components/Dashboard/GoalList/GoalItem/TodoList/index.tsx
@@ -35,7 +35,12 @@ export const TodoList = ({ todo, color }: TodoListProps) => {
             transition={{ duration: 0.3, ease: 'easeInOut' }}
           >
             {todo.completes.map((complete, index) => (
-              <TodoPic key={complete.completeId} index={index} color={color} />
+              <TodoPic
+                key={complete.completeId}
+                index={index}
+                color={color}
+                pic={complete.completePic}
+              />
             ))}
           </motion.div>
         )}

--- a/src/components/Dashboard/GoalList/GoalItem/TodoList/index.tsx
+++ b/src/components/Dashboard/GoalList/GoalItem/TodoList/index.tsx
@@ -40,6 +40,8 @@ export const TodoList = ({ todo, color }: TodoListProps) => {
                 index={index}
                 color={color}
                 pic={complete.completePic}
+                status={complete.completeStatus}
+                date={complete.startDate}
               />
             ))}
           </motion.div>

--- a/src/components/common/Header/index.tsx
+++ b/src/components/common/Header/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { FaBarsStaggered, FaBell } from 'react-icons/fa6';
+
 import { useSidebarStore } from '@/store/useSidebarStore';
 
 interface HeaderProps {
@@ -11,7 +12,7 @@ export const Header = ({ title = '' }: HeaderProps) => {
   const { open } = useSidebarStore();
 
   return (
-    <div className="fixed left-0 top-0 z-10 flex h-48 w-full items-center justify-between bg-white px-16 md:hidden">
+    <div className="fixed left-0 top-0 z-20 flex h-48 w-full items-center justify-between bg-white px-16 md:hidden">
       <div className="flex items-center">
         <FaBarsStaggered
           className="w-24 cursor-pointer text-primary-100"

--- a/src/components/common/Header/index.tsx
+++ b/src/components/common/Header/index.tsx
@@ -12,7 +12,7 @@ export const Header = ({ title = '' }: HeaderProps) => {
   const { open } = useSidebarStore();
 
   return (
-    <div className="fixed left-0 top-0 z-20 flex h-48 w-full items-center justify-between bg-white px-16 md:hidden">
+    <div className="fixed left-0 top-0 z-10 flex h-48 w-full items-center justify-between bg-white px-16 md:hidden">
       <div className="flex items-center">
         <FaBarsStaggered
           className="w-24 cursor-pointer text-primary-100"

--- a/src/hooks/apis/Todo/useCertifiedTodo.ts
+++ b/src/hooks/apis/Todo/useCertifiedTodo.ts
@@ -4,11 +4,12 @@ import {
   useQueryClient,
 } from '@tanstack/react-query';
 import { AxiosError, AxiosResponse } from 'axios';
-import { notify } from '@/store/useToastStore';
-import { QUERY_KEYS } from '@/constants/QueryKeys';
-import { useTodoModalStore } from '@/store/useTodoModalStore';
+
 import { certifiedTodo } from '@/apis/Todo/certifiedTodo';
 import { TOAST_MESSAGES } from '@/constants/Messages';
+import { QUERY_KEYS } from '@/constants/QueryKeys';
+import { notify } from '@/store/useToastStore';
+import { useTodoModalStore } from '@/store/useTodoModalStore';
 
 export interface CertifiedTodoRequest {
   completePicBase64: string;
@@ -40,6 +41,7 @@ export const useCertifiedTodo = (): UseMutationResult<
         queryKey: [QUERY_KEYS.CERTIFIED_RECENT_TODO],
       });
       queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.TODAY_TODO] });
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.TODOS_OF_GOALS] });
       close();
     },
     onError: (error: AxiosError) => {

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -46,3 +46,12 @@ export const formatDateToRelativeTime = (dateString: string): string => {
   const years = Math.floor(months / 12);
   return rtf.format(years, 'year');
 };
+
+export const isDatePast = (dateString: string): boolean => {
+  if (!dateString) return false;
+
+  const today = new Date().setHours(0, 0, 0, 0);
+  const thisDay = new Date(dateString).setHours(0, 0, 0, 0);
+
+  return today > thisDay;
+};

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -14,8 +14,8 @@ export const formatDateToRelativeTime = (dateString: string): string => {
   if (!dateString) return '';
 
   const date = new Date(dateString);
-  const now = Date.now();
-  const timeDifference = date.getTime() - now;
+  const now = new Date();
+  const timeDifference = date.getTime() - now.getTime();
   const rtf = new Intl.RelativeTimeFormat('ko', { numeric: 'auto' });
 
   const seconds = Math.floor(timeDifference / 1000);


### PR DESCRIPTION
# 📄 대시보드 인증 사진 적용

## 📝 변경 사항 요약
- 대시보드 인증 사진 적용
- 기타 수정

## 📌 관련 이슈
- 이슈 번호: #153

## 🔍 변경 사항 상세 설명
### 대시보드 인증 사진 적용
`isDatePast` 함수를 만들어 오늘 날짜 기준으로 해당 인증 날짜가 지났으면 회색으로 지나지 않았으면 해당 목표 색으로 변경하였습니다.
> Jest로 해당 함수 테스팅 진행하였습니다.

인증이 완료된 인증이면 해당 사진을 `opacity-50`으로 적용시켜 목표의 색을 보여주게 하였습니다. 
> 기존 피그마에서는 목표의 색을 opacity를 변경하였지만 반대의 값을 사진에 적용시켜 두었습니다. 피그마 기준으로 하면 opacity-30 적용시켜야 하지만 사진이 너무 안보여서 50으로 수정했습니다.

> 기존 디자인대로 오늘인증해야될 인증 기준으로 순서를 배치하면 현재 index 기반의 순서가 조금 애매하여 그냥 순서대로 두었습니다.

`onLoad`를 통해 이미지 로드가 느릴 경우 스켈레톤으로 나오도록 해두었습니다.
```js
        <Image
          src={pic}
          fill
          alt="인증 사진"
          onLoad={() => setIsLoaded(true)}
          className="rounded-16 object-cover opacity-50"
        />
```

<br />

예시 사진)

<img width="373" alt="image" src="https://github.com/user-attachments/assets/21e14f5d-1d46-463c-b152-18c67e04f30b" />

### 기타 수정
목표의 progress를 정수화 시켰습니다.
> 근데 노란색일 경우에 숫자가 잘 보이지않아 수정 필요할 것 같습니다.

## ✅ 확인 사항
- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 관련 테스트를 작성하고 모두 통과했는지 확인했습니다.
- [x] 코드 스타일 가이드에 맞게 작성했습니다.

## 📸 스크린샷 (선택 사항)

### 내 할일 인증 -> 대시보드

https://github.com/user-attachments/assets/f358b202-5cc7-4ed0-b246-c689fa7e3199

### 인증 사진 스켈레톤

https://github.com/user-attachments/assets/6108f986-6021-4d97-a2f3-3a001fb60a1c


## 기타 참고 사항
대시보드의 최근 등록한 할일에 대해서는 따로 인증 기간의 검증이 없기 때문에 UI를 변경하던가 오늘 할일을 간추려서 보여주는 방식으로 변경되어야 할 것 같습니다.
