### PR TITLE
[Feat] 검색 페이지 api 연동

### DIFF
--- a/src/apis/Search/getSearch.ts
+++ b/src/apis/Search/getSearch.ts
@@ -1,3 +1,4 @@
+import { AxiosError } from 'axios';
 import { API_ENDPOINTS } from '@/constants/ApiEndpoints';
 import { SearchRequest } from '@/hooks/apis/Search/useSearchQuery';
 import axiosInstance from '@/lib/axiosInstance';
@@ -9,6 +10,13 @@ export const getSearch = async (request: SearchRequest) => {
     });
     return response.data;
   } catch (error) {
-    console.log(error);
+    let errorMessage = 'An unknown error occurred.';
+    if (error instanceof AxiosError) {
+      if (error.response) {
+        errorMessage =
+          error.response.data?.message || 'An unknown error occurred.';
+      }
+    }
+    throw new Error(errorMessage);
   }
 };

--- a/src/apis/Search/getSearch.ts
+++ b/src/apis/Search/getSearch.ts
@@ -1,0 +1,14 @@
+import { API_ENDPOINTS } from '@/constants/ApiEndpoints';
+import { SearchRequest } from '@/hooks/apis/Search/useSearchQuery';
+import axiosInstance from '@/lib/axiosInstance';
+
+export const getSearch = async (request: SearchRequest) => {
+  try {
+    const response = await axiosInstance.get(API_ENDPOINTS.SEARCH, {
+      params: request,
+    });
+    return response.data;
+  } catch (error) {
+    console.log(error);
+  }
+};

--- a/src/app/(route)/search/page.tsx
+++ b/src/app/(route)/search/page.tsx
@@ -1,8 +1,19 @@
+'use client';
+
+import { useEffect } from 'react';
 import { SearchContent } from '@/components/Search/SearchContent';
 import { SearchHeader } from '@/components/Search/SearchHeader';
 import { SearchInput } from '@/components/Search/SearchInput';
+import { useSearchStore } from '@/store/useSearchStore';
 
 export default function SearchPage() {
+  const { setSearchFilter, setSearchKeyword } = useSearchStore();
+
+  useEffect(() => {
+    setSearchFilter('유저명');
+    setSearchKeyword('');
+  }, [setSearchFilter, setSearchKeyword]);
+
   return (
     <div className="flex min-h-screen w-screen flex-col gap-16 bg-custom-white-100 p-16 md:px-200 xl:px-400 2xl:px-650">
       <SearchHeader />

--- a/src/components/Search/SearchContent/SearchGoalList/index.tsx
+++ b/src/components/Search/SearchContent/SearchGoalList/index.tsx
@@ -24,8 +24,8 @@ export const SearchGoalList = ({
           {keyword ? `'${keyword}' ${error?.message}` : error?.message}
         </div>
       ) : (
-        searchData?.data.map((item: SearchResponseData, index) => (
-          <li className="flex w-full flex-col" key={index}>
+        searchData?.data.map((item: SearchResponseData) => (
+          <li className="flex w-full flex-col" key={item.userId}>
             <div className="flex w-full items-center gap-8">
               <Image
                 width={48}

--- a/src/components/Search/SearchContent/SearchGoalList/index.tsx
+++ b/src/components/Search/SearchContent/SearchGoalList/index.tsx
@@ -20,7 +20,9 @@ export const SearchGoalList = ({
   return (
     <ul className="flex flex-col gap-16">
       {isError ? (
-        <div className="text-center text-error">{`'${keyword}' ${error?.message}`}</div>
+        <div className="text-center text-error">
+          {keyword ? `'${keyword}' ${error?.message}` : error?.message}
+        </div>
       ) : (
         searchData?.data.map((item: SearchResponseData, index) => (
           <li className="flex w-full flex-col" key={index}>

--- a/src/components/Search/SearchContent/SearchGoalList/index.tsx
+++ b/src/components/Search/SearchContent/SearchGoalList/index.tsx
@@ -1,0 +1,51 @@
+import { AxiosError } from 'axios';
+import Image from 'next/image';
+import { FaFlag } from 'react-icons/fa6';
+import { Goal } from '@/types/Goals';
+import { SearchResponseData } from '@/hooks/apis/Search/useSearchQuery';
+
+interface SearchGoalListProps {
+  isError: boolean;
+  error: AxiosError | null;
+  searchData: { data: SearchResponseData[] } | undefined;
+  keyword: string;
+}
+
+export const SearchGoalList = ({
+  isError,
+  error,
+  searchData,
+  keyword,
+}: SearchGoalListProps) => {
+  return (
+    <ul className="flex flex-col gap-16">
+      {isError ? (
+        <div className="text-center text-error">{`'${keyword}' ${error?.message}`}</div>
+      ) : (
+        searchData?.data.map((item: SearchResponseData, index) => (
+          <li className="flex w-full flex-col" key={index}>
+            <div className="flex w-full items-center gap-8">
+              <Image
+                width={48}
+                height={48}
+                className="flex size-48 rounded-90"
+                src={item.profilePic}
+                alt="프로필 사진"
+              />
+              <span className="text-base-medium">{item.name}</span>
+            </div>
+            {item.goals.map((item: Goal) => (
+              <div
+                className="flex items-start gap-8 py-16 pl-48 pr-16"
+                key={item.goalId}
+              >
+                <FaFlag className="size-18" style={{ fill: item.color }} />
+                <span className="text-base-medium">{item.goalTitle}</span>
+              </div>
+            ))}
+          </li>
+        ))
+      )}
+    </ul>
+  );
+};

--- a/src/components/Search/SearchContent/SearchUserList/index.tsx
+++ b/src/components/Search/SearchContent/SearchUserList/index.tsx
@@ -18,10 +18,12 @@ export const SearchUserList = ({
   return (
     <ul className="flex flex-col gap-16">
       {isError ? (
-        <div className="text-center text-error">{`'${keyword}' ${error?.message}`}</div>
+        <div className="text-center text-error">
+          {keyword ? `'${keyword}' ${error?.message}` : error?.message}
+        </div>
       ) : (
-        searchData?.data.map((item: SearchResponseData, index) => (
-          <li className="flex w-full items-center gap-8" key={index}>
+        searchData?.data.map((item: SearchResponseData) => (
+          <li className="flex w-full items-center gap-8" key={item.userId}>
             <Image
               width={48}
               height={48}

--- a/src/components/Search/SearchContent/SearchUserList/index.tsx
+++ b/src/components/Search/SearchContent/SearchUserList/index.tsx
@@ -1,0 +1,38 @@
+import { AxiosError } from 'axios';
+import Image from 'next/image';
+import { SearchResponseData } from '@/hooks/apis/Search/useSearchQuery';
+
+interface SearchUserListProps {
+  isError: boolean;
+  error: AxiosError | null;
+  searchData: { data: SearchResponseData[] } | undefined;
+  keyword: string;
+}
+
+export const SearchUserList = ({
+  isError,
+  error,
+  searchData,
+  keyword,
+}: SearchUserListProps) => {
+  return (
+    <ul className="flex flex-col gap-16">
+      {isError ? (
+        <div className="text-center text-error">{`'${keyword}' ${error?.message}`}</div>
+      ) : (
+        searchData?.data.map((item: SearchResponseData, index) => (
+          <li className="flex w-full items-center gap-8" key={index}>
+            <Image
+              width={48}
+              height={48}
+              className="flex size-48 rounded-90"
+              src={item.profilePic}
+              alt="프로필 사진"
+            />
+            <span className="text-base-medium">{item.name}</span>
+          </li>
+        ))
+      )}
+    </ul>
+  );
+};

--- a/src/components/Search/SearchContent/index.tsx
+++ b/src/components/Search/SearchContent/index.tsx
@@ -1,64 +1,47 @@
 'use client';
 
-import Image from 'next/image';
-import { FaFlag } from 'react-icons/fa6';
+import { useEffect } from 'react';
+
 import { useSearchStore } from '@/store/useSearchStore';
-import { Goal } from '@/types/Goals';
-import {
-  SearchResponseData,
-  useSearchQuery,
-} from '@/hooks/apis/Search/useSearchQuery';
+import { useSearchQuery } from '@/hooks/apis/Search/useSearchQuery';
+
+import { SearchUserList } from './SearchUserList';
+import { SearchGoalList } from './SearchGoalList';
 
 export const SearchContent = () => {
   const { searchFilter, searchKeyword } = useSearchStore();
-  const { data: searchData } = useSearchQuery({
+  const {
+    data: searchData,
+    refetch,
+    isError,
+    error,
+  } = useSearchQuery({
     searchField: searchFilter,
     keyword: searchKeyword,
   });
 
+  useEffect(() => {
+    if (searchKeyword || searchFilter) {
+      refetch();
+    }
+  }, [searchKeyword, searchFilter, refetch]);
+
   return (
     <div>
       {searchFilter === '유저명' ? (
-        <ul className="flex flex-col gap-16">
-          {searchData?.data.map((item: SearchResponseData) => (
-            <li className="flex w-full items-center gap-8" key={item.name}>
-              <Image
-                width={48}
-                height={48}
-                className="flex size-48 rounded-90"
-                src={item.profilePic}
-                alt="프로필 사진"
-              />
-              <span className="text-base-medium">{item.name}</span>
-            </li>
-          ))}
-        </ul>
+        <SearchUserList
+          isError={isError}
+          error={error}
+          searchData={searchData}
+          keyword={searchKeyword}
+        />
       ) : (
-        <ul className="flex flex-col gap-16">
-          {searchData?.data.map((item: SearchResponseData) => (
-            <li className="flex w-full flex-col" key={item.name}>
-              <div className="flex w-full items-center gap-8">
-                <Image
-                  width={48}
-                  height={48}
-                  className="flex size-48 rounded-90"
-                  src={item.profilePic}
-                  alt="프로필 사진"
-                />
-                <span className="text-base-medium">{item.name}</span>
-              </div>
-              {item.goals.map((item: Goal) => (
-                <div
-                  className="flex items-start gap-8 py-16 pl-48 pr-16"
-                  key={item.goalId}
-                >
-                  <FaFlag className="size-18" style={{ fill: item.color }} />
-                  <span className="text-base-medium">{item.goalTitle}</span>
-                </div>
-              ))}
-            </li>
-          ))}
-        </ul>
+        <SearchGoalList
+          isError={isError}
+          error={error}
+          searchData={searchData}
+          keyword={searchKeyword}
+        />
       )}
     </div>
   );

--- a/src/components/Search/SearchContent/index.tsx
+++ b/src/components/Search/SearchContent/index.tsx
@@ -4,95 +4,23 @@ import Image from 'next/image';
 import { FaFlag } from 'react-icons/fa6';
 import { useSearchStore } from '@/store/useSearchStore';
 import { Goal } from '@/types/Goals';
-
-const users = [
-  {
-    profilePic:
-      'https://slid-todo.s3.ap-northeast-2.amazonaws.com/a19c4793-d33b-4be6-9f65-097bed5a6709_testmouse1.png',
-    name: '닉네임1',
-  },
-  {
-    profilePic:
-      'https://slid-todo.s3.ap-northeast-2.amazonaws.com/a19c4793-d33b-4be6-9f65-097bed5a6709_testmouse1.png',
-    name: '닉네임2',
-  },
-  {
-    profilePic:
-      'https://slid-todo.s3.ap-northeast-2.amazonaws.com/a19c4793-d33b-4be6-9f65-097bed5a6709_testmouse1.png',
-    name: '닉네임3',
-  },
-  {
-    profilePic:
-      'https://slid-todo.s3.ap-northeast-2.amazonaws.com/a19c4793-d33b-4be6-9f65-097bed5a6709_testmouse1.png',
-    name: '닉네임4',
-  },
-  {
-    profilePic:
-      'https://slid-todo.s3.ap-northeast-2.amazonaws.com/a19c4793-d33b-4be6-9f65-097bed5a6709_testmouse1.png',
-    name: '닉네임5',
-  },
-];
-
-const userGoals = [
-  {
-    profilePic:
-      'https://slid-todo.s3.ap-northeast-2.amazonaws.com/a19c4793-d33b-4be6-9f65-097bed5a6709_testmouse1.png',
-    name: '닉네임1',
-    goals: [
-      {
-        goalId: 1,
-        goalTitle: '목표 1',
-        color: 'orange',
-        createdAt: '',
-      },
-      {
-        goalId: 2,
-        goalTitle: '목표 2',
-        color: 'purple',
-        createdAt: '',
-      },
-    ],
-  },
-  {
-    profilePic:
-      'https://slid-todo.s3.ap-northeast-2.amazonaws.com/a19c4793-d33b-4be6-9f65-097bed5a6709_testmouse1.png',
-    name: '닉네임2',
-    goals: [
-      {
-        goalId: 1,
-        goalTitle: '목표 1',
-        color: 'orange',
-        createdAt: '',
-      },
-      {
-        goalId: 2,
-        goalTitle: '목표 2',
-        color: 'purple',
-        createdAt: '',
-      },
-    ],
-  },
-];
-
-interface Users {
-  profilePic: string;
-  name: string;
-}
-
-interface UserGoals {
-  profilePic: string;
-  name: string;
-  goals: Goal[];
-}
+import {
+  SearchResponseData,
+  useSearchQuery,
+} from '@/hooks/apis/Search/useSearchQuery';
 
 export const SearchContent = () => {
-  const { searchFilter } = useSearchStore();
+  const { searchFilter, searchKeyword } = useSearchStore();
+  const { data: searchData } = useSearchQuery({
+    searchField: searchFilter,
+    keyword: searchKeyword,
+  });
 
   return (
     <div>
       {searchFilter === '유저명' ? (
         <ul className="flex flex-col gap-16">
-          {users.map((item: Users) => (
+          {searchData?.data.map((item: SearchResponseData) => (
             <li className="flex w-full items-center gap-8" key={item.name}>
               <Image
                 width={48}
@@ -107,7 +35,7 @@ export const SearchContent = () => {
         </ul>
       ) : (
         <ul className="flex flex-col gap-16">
-          {userGoals.map((item: UserGoals) => (
+          {searchData?.data.map((item: SearchResponseData) => (
             <li className="flex w-full flex-col" key={item.name}>
               <div className="flex w-full items-center gap-8">
                 <Image

--- a/src/components/Search/SearchInput/SearchFilterDropdown/index.tsx
+++ b/src/components/Search/SearchInput/SearchFilterDropdown/index.tsx
@@ -2,14 +2,20 @@ import { useState } from 'react';
 import { FaAngleDown } from 'react-icons/fa6';
 import { Dropdown } from '@/components/common/Dropdown';
 import { SEARCH_FILTER_ARRAY } from '@/constants/SearchFilterArray';
-import { useSearchStore } from '@/store/useSearchStore';
 
 interface filterType {
   searchFilter: string;
 }
 
-export const SearchFilterDropdown = () => {
-  const { searchFilter, setSearchFilter } = useSearchStore();
+interface SearchFilterDropdownProps {
+  localFilter: string;
+  setLocalFilter: (filter: string) => void;
+}
+
+export const SearchFilterDropdown = ({
+  localFilter,
+  setLocalFilter,
+}: SearchFilterDropdownProps) => {
   const [isOpenDropdown, setIsOpenDropdown] = useState(false);
 
   const handleDropdown = () => {
@@ -17,7 +23,7 @@ export const SearchFilterDropdown = () => {
   };
 
   const handleSelectItem = (item: filterType) => {
-    setSearchFilter(item.searchFilter);
+    setLocalFilter(item.searchFilter);
   };
 
   const renderDropdownItem = (item: filterType) => {
@@ -33,11 +39,9 @@ export const SearchFilterDropdown = () => {
       className="relative flex w-80 cursor-pointer items-center gap-4"
       onClick={handleDropdown}
     >
-      <span className="text-sm-medium text-custom-gray-100">
-        {searchFilter}
-      </span>
+      <span className="text-sm-medium text-custom-gray-100">{localFilter}</span>
       <FaAngleDown
-        className={`size-14 cursor-pointer text-custom-gray-100 transition-transform duration-300 ${isOpenDropdown ? 'rotate-180' : ''}`}
+        className={`size-18 cursor-pointer text-custom-gray-100 transition-transform duration-300 ${isOpenDropdown ? 'rotate-180' : ''}`}
       />
       <Dropdown
         dropdownData={SEARCH_FILTER_ARRAY}

--- a/src/components/Search/SearchInput/SearchFilterDropdown/index.tsx
+++ b/src/components/Search/SearchInput/SearchFilterDropdown/index.tsx
@@ -41,7 +41,7 @@ export const SearchFilterDropdown = ({
     >
       <span className="text-sm-medium text-custom-gray-100">{localFilter}</span>
       <FaAngleDown
-        className={`size-18 cursor-pointer text-custom-gray-100 transition-transform duration-300 ${isOpenDropdown ? 'rotate-180' : ''}`}
+        className={`size-14 cursor-pointer text-custom-gray-100 transition-transform duration-300 ${isOpenDropdown ? 'rotate-180' : ''}`}
       />
       <Dropdown
         dropdownData={SEARCH_FILTER_ARRAY}

--- a/src/components/Search/SearchInput/index.tsx
+++ b/src/components/Search/SearchInput/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ChangeEvent } from 'react';
+import { ChangeEvent, KeyboardEvent, useState } from 'react';
 import { FaSearch } from 'react-icons/fa';
 import { Input } from '@/components/common/Input';
 import { PLACEHOLDERS } from '@/constants/Placeholders';
@@ -8,26 +8,38 @@ import { useSearchStore } from '@/store/useSearchStore';
 import { SearchFilterDropdown } from './SearchFilterDropdown';
 
 export const SearchInput = () => {
-  const { searchKeyword, setSearchKeyword, setIsSearchClicked } =
-    useSearchStore();
+  const [localKeyword, setLocalKeyword] = useState('');
+  const [localFilter, setLocalFilter] = useState('유저명');
+  const { setSearchKeyword, setSearchFilter } = useSearchStore();
 
   const handleKeyword = (e: ChangeEvent<HTMLInputElement>) => {
-    setSearchKeyword(e.target.value);
+    setLocalKeyword(e.target.value);
+  };
+
+  const handleKeyPress = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      handleClick();
+    }
   };
 
   const handleClick = () => {
-    setIsSearchClicked(true);
+    setSearchKeyword(localKeyword);
+    setSearchFilter(localFilter);
   };
 
   return (
     <div className="flex h-48 w-full items-center justify-between rounded-62 bg-white px-16 py-8">
       <div className="flex items-center gap-16">
-        <SearchFilterDropdown />
+        <SearchFilterDropdown
+          localFilter={localFilter}
+          setLocalFilter={setLocalFilter}
+        />
         <Input
           className="px-0"
           placeholder={PLACEHOLDERS.SEARCH}
-          value={searchKeyword}
+          value={localKeyword}
           onChange={handleKeyword}
+          onKeyDown={handleKeyPress}
         />
       </div>
       <FaSearch

--- a/src/components/common/Header/index.tsx
+++ b/src/components/common/Header/index.tsx
@@ -1,8 +1,6 @@
 'use client';
 
 import { FaBarsStaggered, FaBell } from 'react-icons/fa6';
-import { FaSearch } from 'react-icons/fa';
-import { useRouter } from 'next/navigation';
 import { useSidebarStore } from '@/store/useSidebarStore';
 
 interface HeaderProps {
@@ -11,11 +9,6 @@ interface HeaderProps {
 
 export const Header = ({ title = '' }: HeaderProps) => {
   const { open } = useSidebarStore();
-  const router = useRouter();
-
-  const handleClickSearch = () => {
-    router.push('/search');
-  };
 
   return (
     <div className="fixed left-0 top-0 z-10 flex h-48 w-full items-center justify-between bg-white px-16 md:hidden">
@@ -27,13 +20,7 @@ export const Header = ({ title = '' }: HeaderProps) => {
         />
         <p className="ml-16 text-base-semibold">{title}</p>
       </div>
-      <div className="flex gap-8">
-        <FaSearch
-          className="size-24 cursor-pointer p-4 text-primary-100"
-          onClick={handleClickSearch}
-        />
-        <FaBell className="right-0 size-24 cursor-pointer p-4 text-primary-100" />
-      </div>
+      <FaBell className="right-0 size-24 cursor-pointer p-4 text-primary-100" />
     </div>
   );
 };

--- a/src/components/common/Header/index.tsx
+++ b/src/components/common/Header/index.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { FaBarsStaggered, FaBell } from 'react-icons/fa6';
-
+import { FaSearch } from 'react-icons/fa';
+import { useRouter } from 'next/navigation';
 import { useSidebarStore } from '@/store/useSidebarStore';
 
 interface HeaderProps {
@@ -10,6 +11,11 @@ interface HeaderProps {
 
 export const Header = ({ title = '' }: HeaderProps) => {
   const { open } = useSidebarStore();
+  const router = useRouter();
+
+  const handleClickSearch = () => {
+    router.push('/search');
+  };
 
   return (
     <div className="fixed left-0 top-0 z-10 flex h-48 w-full items-center justify-between bg-white px-16 md:hidden">
@@ -21,7 +27,13 @@ export const Header = ({ title = '' }: HeaderProps) => {
         />
         <p className="ml-16 text-base-semibold">{title}</p>
       </div>
-      <FaBell className="right-0 size-24 cursor-pointer p-4 text-primary-100" />
+      <div className="flex gap-8">
+        <FaSearch
+          className="size-24 cursor-pointer p-4 text-primary-100"
+          onClick={handleClickSearch}
+        />
+        <FaBell className="right-0 size-24 cursor-pointer p-4 text-primary-100" />
+      </div>
     </div>
   );
 };

--- a/src/constants/ApiEndpoints.ts
+++ b/src/constants/ApiEndpoints.ts
@@ -26,4 +26,5 @@ export const API_ENDPOINTS = {
     ALL_GOALS: '/api/v1/goals/all',
     GOAL: (goalId: number) => `/api/v1/goals/${goalId}`,
   },
+  SEARCH: '/api/v1/searches',
 };

--- a/src/constants/QueryKeys.ts
+++ b/src/constants/QueryKeys.ts
@@ -6,7 +6,7 @@ export const QUERY_KEYS = {
   RECENT_TODOS: 'recentTodos',
   USER_INFO: 'userInfo',
   TODAY_TODO: 'todayTodo',
-
+  SEARCH_DATA: 'searchData',
   CERTIFIED_TODO: 'certifiedTodo',
   CERTIFIED_RECENT_TODO: 'certifiedRecentTodo',
   FOLLOW_COUNT: 'followCount',

--- a/src/hooks/apis/Search/useSearchQuery.ts
+++ b/src/hooks/apis/Search/useSearchQuery.ts
@@ -30,8 +30,5 @@ const searchOptions = (
 });
 
 export const useSearchQuery = (request: SearchRequest) => {
-  const { data, isLoading, isError, error, refetch } = useQuery(
-    searchOptions(request),
-  );
-  return { data, isLoading, isError, error, refetch };
+  return useQuery(searchOptions(request));
 };

--- a/src/hooks/apis/Search/useSearchQuery.ts
+++ b/src/hooks/apis/Search/useSearchQuery.ts
@@ -1,0 +1,41 @@
+import { useQuery, UseQueryOptions } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+import { Goal } from '@/types/Goals';
+import { QUERY_KEYS } from '@/constants/QueryKeys';
+import { getSearch } from '@/apis/Search/getSearch';
+import { useSearchStore } from '@/store/useSearchStore';
+
+export interface SearchResponseData {
+  name: string;
+  profilePic: string;
+  goals: Goal[];
+}
+
+export interface SearchResponse {
+  statusCode: number;
+  data: SearchResponseData[];
+  timestamp: string;
+}
+
+export interface SearchRequest {
+  searchField: string;
+  keyword: string;
+}
+
+const searchOptions = (
+  request: SearchRequest,
+  isSearchClicked: boolean,
+  searchKeyword: string,
+): UseQueryOptions<SearchResponse, AxiosError> => ({
+  queryKey: [QUERY_KEYS.SEARCH_DATA],
+  queryFn: () => getSearch(request),
+  enabled: isSearchClicked && Boolean(searchKeyword),
+});
+
+export const useSearchQuery = (request: SearchRequest) => {
+  const { isSearchClicked, searchKeyword } = useSearchStore();
+  const { data, isLoading, isError, error } = useQuery(
+    searchOptions(request, isSearchClicked, searchKeyword),
+  );
+  return { data, isLoading, isError, error };
+};

--- a/src/hooks/apis/Search/useSearchQuery.ts
+++ b/src/hooks/apis/Search/useSearchQuery.ts
@@ -3,7 +3,6 @@ import { AxiosError } from 'axios';
 import { Goal } from '@/types/Goals';
 import { QUERY_KEYS } from '@/constants/QueryKeys';
 import { getSearch } from '@/apis/Search/getSearch';
-import { useSearchStore } from '@/store/useSearchStore';
 
 export interface SearchResponseData {
   name: string;
@@ -15,6 +14,7 @@ export interface SearchResponse {
   statusCode: number;
   data: SearchResponseData[];
   timestamp: string;
+  message: string;
 }
 
 export interface SearchRequest {
@@ -24,18 +24,14 @@ export interface SearchRequest {
 
 const searchOptions = (
   request: SearchRequest,
-  isSearchClicked: boolean,
-  searchKeyword: string,
 ): UseQueryOptions<SearchResponse, AxiosError> => ({
   queryKey: [QUERY_KEYS.SEARCH_DATA],
   queryFn: () => getSearch(request),
-  enabled: isSearchClicked && Boolean(searchKeyword),
 });
 
 export const useSearchQuery = (request: SearchRequest) => {
-  const { isSearchClicked, searchKeyword } = useSearchStore();
-  const { data, isLoading, isError, error } = useQuery(
-    searchOptions(request, isSearchClicked, searchKeyword),
+  const { data, isLoading, isError, error, refetch } = useQuery(
+    searchOptions(request),
   );
-  return { data, isLoading, isError, error };
+  return { data, isLoading, isError, error, refetch };
 };

--- a/src/hooks/apis/Search/useSearchQuery.ts
+++ b/src/hooks/apis/Search/useSearchQuery.ts
@@ -1,13 +1,14 @@
 import { useQuery, UseQueryOptions } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
-import { Goal } from '@/types/Goals';
 import { QUERY_KEYS } from '@/constants/QueryKeys';
 import { getSearch } from '@/apis/Search/getSearch';
+import { GoalTypes } from '@/types/data';
 
 export interface SearchResponseData {
+  userId: number;
   name: string;
   profilePic: string;
-  goals: Goal[];
+  goals: GoalTypes[];
 }
 
 export interface SearchResponse {


### PR DESCRIPTION
# 📄 검색 페이지 api 연동

## 📝 변경 사항 요약
- 검색 api, hook 생성 (쿼리 파라미터)
- header 컴포넌트의 검색페이지로의 라우터 설정
- 검색 로직 구현 (에러처리, 검색 리패치, 상태관리, 상태 초기화)

## 📌 관련 이슈
- 이슈 번호: #150 

## 🔍 변경 사항 상세 설명
검색 api와 hook을 분리한 이유는 기존의 HTTP service에서 제공된 GET의 코드를 수정하고 적용시켰지만 
쿼리 파라미터와 에러처리 때문에 다른 코드에서도 문제가 생길까봐! 일단 기존 방법으로 진행하였습니다.

api 함수에서 나온 에러 메시지를 받아 검색 결과에 적용을 시켰습니다.

드롭다운과 input의 값이 변경될 때마다 검색 결과를 바꾸는 것이 아닌
enter키를 누르거나 검색 아이콘을 눌렀을 때 결과가 실행되도록 의도를 하였기에 
enter키를 누르거나 검색 아이콘을 눌렀을 때마다 상태가 바뀌도록 처리하였습니다.

그 후 상태가 바뀔때마다 리패치를 시켜주었습니다. (쿼리 키 특정시키면 따로 처리안해줘도 될듯? 일단 우선적으로 이렇게 적용)

마지막으로 페이지를 나갔다가 들어오는 과정에서 상태값을 초기화 (안시켜주면 이전 데이터가 남아있음)


## ✅ 확인 사항
- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 관련 테스트를 작성하고 모두 통과했는지 확인했습니다.
- [x] 코드 스타일 가이드에 맞게 작성했습니다.

## 📸 스크린샷 (선택 사항)
![검색 페이지2 최종 Gif](https://github.com/user-attachments/assets/c3dd88dd-0ce8-4d57-8f1d-3cfae5eea015)



## 기타 참고 사항
추가로 공유하고 싶은 내용이나 참고 자료가 있다면 여기에 작성해주세요.
