### PR TITLE
[Refactor] Add loading to infinite scroll

### DIFF
--- a/src/app/(route)/goals/page.tsx
+++ b/src/app/(route)/goals/page.tsx
@@ -6,7 +6,7 @@ export default function GoalsPage() {
     <>
       <Header />
       <div className="flex min-h-screen w-screen flex-col gap-16 bg-custom-white-100 px-16 pb-16 pt-48">
-        <h1 className="pl-4 pt-16 text-xl-bold">목표</h1>
+        <h1 className="pl-4 pt-16 text-xl-semibold">목표</h1>
         <GoalList />
       </div>
     </>

--- a/src/components/Dashboard/GoalList/GoalItem/TodoList/TodoHeader/index.tsx
+++ b/src/components/Dashboard/GoalList/GoalItem/TodoList/TodoHeader/index.tsx
@@ -2,7 +2,8 @@ import { motion } from 'motion/react';
 import { FaAngleDown } from 'react-icons/fa6';
 
 import { TodoTypes } from '@/types/data';
-import { formatDateToPoint } from '@/utils/date';
+import { cn } from '@/utils/className';
+import { formatDateToPoint, isDatePast } from '@/utils/date';
 
 interface TodoHeaderProps {
   open: () => void;
@@ -11,12 +12,17 @@ interface TodoHeaderProps {
 }
 
 export const TodoHeader = ({ open, todo, isOpen }: TodoHeaderProps) => {
+  const isPast = isDatePast(todo.endDate);
+  const titleClass = cn('text-base-semibold', isPast && 'text-custom-gray-100');
+
   return (
     <div onClick={open} className="relative mt-16">
       <div className="">
-        <p className="text-base-semibold">{todo.todoTitle}</p>
+        <p className={titleClass}>{todo.todoTitle}</p>
         <p className="text-xs-medium leading-6 text-custom-gray-100">
-          {`${formatDateToPoint(todo.startDate)} - 
+          {isPast
+            ? '종료'
+            : `${formatDateToPoint(todo.startDate)} - 
           ${formatDateToPoint(todo.endDate)}`}
         </p>
       </div>

--- a/src/components/Dashboard/GoalList/GoalItem/TodoList/TodoPic/index.tsx
+++ b/src/components/Dashboard/GoalList/GoalItem/TodoList/TodoPic/index.tsx
@@ -21,7 +21,7 @@ export const TodoPic = ({ index, color, pic, status, date }: TodoItemProps) => {
     status === '인증' ? color : isPast ? '#E9E9E9' : color;
   const textClass = cn(
     'absolute inset-0 flex-center !text-base-medium',
-    isPast ? 'text-custom-gray-100' : 'text-custom-gray-300',
+    isPast && !pic ? 'text-custom-gray-100' : 'text-custom-gray-300',
   );
 
   return (

--- a/src/components/Dashboard/GoalList/index.tsx
+++ b/src/components/Dashboard/GoalList/index.tsx
@@ -1,19 +1,25 @@
 'use client';
 
 import { Card } from '@/components/common/Card';
+import { NoDataText } from '@/components/common/NoDataText';
+import { Spinner } from '@/components/common/Spinner';
 import { DashboardItemContainer } from '@/components/Dashboard/DashboardItemContainer';
 import { GoalItem } from '@/components/Dashboard/GoalList/GoalItem';
+import { GoalListSkeleon } from '@/components/Skeletons/GoalListSkeleton';
 
 import { useTodosOfGoalsQuery } from '@/hooks/apis/Dashboard/useTodosOfGoalsQuery';
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
 
 export const GoalList = () => {
-  const { goals, fetchNextPage, isLoading } = useTodosOfGoalsQuery();
+  const { goals, fetchNextPage, isLoading, isFetchingNextPage } =
+    useTodosOfGoalsQuery();
   const { observerRef } = useInfiniteScroll({ fetchNextPage, isLoading });
 
   return (
     <DashboardItemContainer title="목표 별 할 일">
-      {goals.length > 0 ? (
+      {isLoading ? (
+        <GoalListSkeleon />
+      ) : goals.length > 0 ? (
         <div className="flex flex-col gap-16">
           {goals.map((goal) => (
             <GoalItem
@@ -25,13 +31,12 @@ export const GoalList = () => {
               todos={goal.todos}
             />
           ))}
+          {isFetchingNextPage && <Spinner />}
           <div ref={observerRef} style={{ height: '1px' }} />
         </div>
       ) : (
         <Card>
-          <p className="text-sm-normal text-custom-gray-100">
-            등록된 목표가 없습니다.
-          </p>
+          <NoDataText text="등록된 목표가 없습니다." />
         </Card>
       )}
     </DashboardItemContainer>

--- a/src/components/Dashboard/GoalList/index.tsx
+++ b/src/components/Dashboard/GoalList/index.tsx
@@ -6,6 +6,7 @@ import { Spinner } from '@/components/common/Spinner';
 import { DashboardItemContainer } from '@/components/Dashboard/DashboardItemContainer';
 import { GoalItem } from '@/components/Dashboard/GoalList/GoalItem';
 import { GoalListSkeleon } from '@/components/Skeletons/GoalListSkeleton';
+import { NO_DATA_TEXT } from '@/constants/NoDataText';
 
 import { useTodosOfGoalsQuery } from '@/hooks/apis/Dashboard/useTodosOfGoalsQuery';
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
@@ -36,7 +37,7 @@ export const GoalList = () => {
         </div>
       ) : (
         <Card>
-          <NoDataText text="등록된 목표가 없습니다." />
+          <NoDataText text={NO_DATA_TEXT.NO_GOAL} />
         </Card>
       )}
     </DashboardItemContainer>

--- a/src/components/Dashboard/GoalList/index.tsx
+++ b/src/components/Dashboard/GoalList/index.tsx
@@ -32,7 +32,11 @@ export const GoalList = () => {
               todos={goal.todos}
             />
           ))}
-          {isFetchingNextPage && <Spinner />}
+          {isFetchingNextPage && (
+            <span className="flex w-full justify-center">
+              <Spinner className="size-18" />
+            </span>
+          )}
           <div ref={observerRef} style={{ height: '1px' }} />
         </div>
       ) : (

--- a/src/components/Dashboard/RecentTodos/index.tsx
+++ b/src/components/Dashboard/RecentTodos/index.tsx
@@ -10,6 +10,7 @@ import { TodoItem } from '@/components/Todos';
 import { Button } from '@/components/common/Button/Button';
 import { Card } from '@/components/common/Card';
 import { NoDataText } from '@/components/common/NoDataText';
+import { NO_DATA_TEXT } from '@/constants/NoDataText';
 import { useRecentTodosQuery } from '@/hooks/apis/Dashboard/useRecnetTodosQuery';
 import { useGoalsQuery } from '@/hooks/apis/useGoalsQuery';
 import { useSidebarStore } from '@/store/useSidebarStore';
@@ -34,14 +35,14 @@ export const RecentTodos = () => {
         <TodoListSkeleton />
       ) : goals.length === 0 ? (
         <Card>
-          <NoDataText text="목표 먼저 등록 후 할 일을 설정해주세요." />
+          <NoDataText text={NO_DATA_TEXT.NO_TODO_AND_GOAL} />
           <Button onClick={openSidebar} size="medium">
             새 목표 등록
           </Button>
         </Card>
       ) : todos.length === 0 ? (
         <Card>
-          <NoDataText text="등록된 할 일이 없습니다." />
+          <NoDataText text={NO_DATA_TEXT.NO_TODO} />
           <Button onClick={() => openModal('생성')} size="medium">
             새 할일 등록
           </Button>

--- a/src/components/Dashboard/RecentTodos/index.tsx
+++ b/src/components/Dashboard/RecentTodos/index.tsx
@@ -5,10 +5,11 @@ import { FaAngleRight } from 'react-icons/fa6';
 import Link from 'next/link';
 
 import { DashboardItemContainer } from '@/components/Dashboard/DashboardItemContainer';
+import { TodoListSkeleton } from '@/components/Skeletons/TodoListSkeleton';
 import { TodoItem } from '@/components/Todos';
 import { Button } from '@/components/common/Button/Button';
 import { Card } from '@/components/common/Card';
-import { Skeleton } from '@/components/common/Skeleton';
+import { NoDataText } from '@/components/common/NoDataText';
 import { useRecentTodosQuery } from '@/hooks/apis/Dashboard/useRecnetTodosQuery';
 import { useGoalsQuery } from '@/hooks/apis/useGoalsQuery';
 import { useSidebarStore } from '@/store/useSidebarStore';
@@ -30,31 +31,17 @@ export const RecentTodos = () => {
         모두 보기 <FaAngleRight className="ml-8" />
       </Link>
       {isLoading ? (
-        <div>
-          {Array.from({ length: 3 }, (_, index) => (
-            <div key={index} className="flex h-72">
-              <Skeleton className="my-8 size-56 rounded-16" />
-              <div className="ml-16 flex h-72 flex-col items-start justify-center gap-10">
-                <Skeleton className="h-12 w-40 rounded-16" />
-                <Skeleton className="h-20 w-120 rounded-16" />
-              </div>
-            </div>
-          ))}
-        </div>
+        <TodoListSkeleton />
       ) : goals.length === 0 ? (
         <Card>
-          <p className="text-sm-normal text-custom-gray-100">
-            목표 먼저 등록 후 할 일을 설정해주세요.
-          </p>
+          <NoDataText text="목표 먼저 등록 후 할 일을 설정해주세요." />
           <Button onClick={openSidebar} size="medium">
             새 목표 등록
           </Button>
         </Card>
       ) : todos.length === 0 ? (
         <Card>
-          <p className="text-sm-normal text-custom-gray-100">
-            등록된 할 일이 없습니다.
-          </p>
+          <NoDataText text="등록된 할 일이 없습니다." />
           <Button onClick={() => openModal('생성')} size="medium">
             새 할일 등록
           </Button>

--- a/src/components/Goals/GoalList/index.tsx
+++ b/src/components/Goals/GoalList/index.tsx
@@ -17,31 +17,37 @@ export const GoalList = () => {
   const { observerRef } = useInfiniteScroll({ fetchNextPage, isLoading });
 
   return (
-    <div className="flex flex-col gap-16">
+    <>
       {isLoading ? (
         <GoalListSkeleon />
       ) : goals.length > 0 ? (
-        goals.map((goal) => (
-          <div
-            key={goal.goalId}
-            className="relative w-full rounded-12 bg-white p-16 shadow-sm"
-          >
-            <GoalHeader
-              id={goal.goalId}
-              title={goal.goalTitle}
-              color={goal.goalColor}
-            />
-            <ProgressLine percent={goal.progress} color={goal.goalColor} />
-            {goal.todos.map((todo) => (
-              <TodoList key={todo.todoId} todo={todo} color={goal.goalColor} />
-            ))}
-          </div>
-        ))
+        <div className="flex flex-col gap-16">
+          {goals.map((goal) => (
+            <div
+              key={goal.goalId}
+              className="relative w-full rounded-12 bg-white p-16 shadow-sm"
+            >
+              <GoalHeader
+                id={goal.goalId}
+                title={goal.goalTitle}
+                color={goal.goalColor}
+              />
+              <ProgressLine percent={goal.progress} color={goal.goalColor} />
+              {goal.todos.map((todo) => (
+                <TodoList
+                  key={todo.todoId}
+                  todo={todo}
+                  color={goal.goalColor}
+                />
+              ))}
+            </div>
+          ))}
+          {isFetchingNextPage && <Spinner />}
+          <div ref={observerRef} style={{ height: '1px' }} />
+        </div>
       ) : (
         <NoDataText text="등록된 목표가 없습니다." />
       )}
-      {isFetchingNextPage && <Spinner />}
-      <div ref={observerRef} style={{ height: '1px' }} />
-    </div>
+    </>
   );
 };

--- a/src/components/Goals/GoalList/index.tsx
+++ b/src/components/Goals/GoalList/index.tsx
@@ -8,6 +8,7 @@ import { useGoalsDetailQuery } from '@/hooks/apis/Goals/useGoalsDetailQuery';
 import { NoDataText } from '@/components/common/NoDataText';
 import { Spinner } from '@/components/common/Spinner';
 import { GoalListSkeleon } from '@/components/Skeletons/GoalListSkeleton';
+import { NO_DATA_TEXT } from '@/constants/NoDataText';
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
 import { GoalHeader } from './GoalHeader';
 
@@ -46,7 +47,7 @@ export const GoalList = () => {
           <div ref={observerRef} style={{ height: '1px' }} />
         </div>
       ) : (
-        <NoDataText text="등록된 목표가 없습니다." />
+        <NoDataText text={NO_DATA_TEXT.NO_GOAL} />
       )}
     </>
   );

--- a/src/components/Goals/GoalList/index.tsx
+++ b/src/components/Goals/GoalList/index.tsx
@@ -50,7 +50,11 @@ export const GoalList = () => {
               </div>
             );
           })}
-          {isFetchingNextPage && <Spinner />}
+          {isFetchingNextPage && (
+            <span className="flex w-full justify-center">
+              <Spinner className="size-18" />
+            </span>
+          )}
           <div ref={observerRef} style={{ height: '1px' }} />
         </div>
       ) : (

--- a/src/components/Goals/GoalList/index.tsx
+++ b/src/components/Goals/GoalList/index.tsx
@@ -5,7 +5,7 @@ import { TodoList } from '@/components/Dashboard/GoalList/GoalItem/TodoList';
 
 import { useGoalsDetailQuery } from '@/hooks/apis/Goals/useGoalsDetailQuery';
 
-import { EmptyStateText } from '@/components/common/EmptyStateText';
+import { NoDataText } from '@/components/common/NoDataText';
 import { Spinner } from '@/components/common/Spinner';
 import { GoalListSkeleon } from '@/components/Skeletons/GoalListSkeleton';
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
@@ -38,7 +38,7 @@ export const GoalList = () => {
           </div>
         ))
       ) : (
-        <EmptyStateText text="등록된 목표가 없습니다." />
+        <NoDataText text="등록된 목표가 없습니다." />
       )}
       {isFetchingNextPage && <Spinner />}
       <div ref={observerRef} style={{ height: '1px' }} />

--- a/src/components/Goals/GoalList/index.tsx
+++ b/src/components/Goals/GoalList/index.tsx
@@ -5,15 +5,19 @@ import { TodoList } from '@/components/Dashboard/GoalList/GoalItem/TodoList';
 
 import { useGoalsDetailQuery } from '@/hooks/apis/Goals/useGoalsDetailQuery';
 
+import { Spinner } from '@/components/common/Spinner';
+import { GoalListSkeleon } from '@/components/Skeletons/GoalListSkeleton';
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
 import { GoalHeader } from './GoalHeader';
 
 export const GoalList = () => {
-  const { goals, fetchNextPage, isLoading } = useGoalsDetailQuery();
+  const { goals, fetchNextPage, isLoading, isFetchingNextPage } =
+    useGoalsDetailQuery();
   const { observerRef } = useInfiniteScroll({ fetchNextPage, isLoading });
 
   return (
     <div className="flex flex-col gap-16">
+      {isLoading && <GoalListSkeleon />}
       {goals.map((goal) => (
         <div
           key={goal.goalId}
@@ -30,6 +34,7 @@ export const GoalList = () => {
           ))}
         </div>
       ))}
+      {isFetchingNextPage && <Spinner />}
       <div ref={observerRef} style={{ height: '1px' }} />
     </div>
   );

--- a/src/components/Goals/GoalList/index.tsx
+++ b/src/components/Goals/GoalList/index.tsx
@@ -10,6 +10,7 @@ import { Spinner } from '@/components/common/Spinner';
 import { GoalListSkeleon } from '@/components/Skeletons/GoalListSkeleton';
 import { NO_DATA_TEXT } from '@/constants/NoDataText';
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
+import { compareDates } from '@/utils/date';
 import { GoalHeader } from './GoalHeader';
 
 export const GoalList = () => {
@@ -23,26 +24,32 @@ export const GoalList = () => {
         <GoalListSkeleon />
       ) : goals.length > 0 ? (
         <div className="flex flex-col gap-16">
-          {goals.map((goal) => (
-            <div
-              key={goal.goalId}
-              className="relative w-full rounded-12 bg-white p-16 shadow-sm"
-            >
-              <GoalHeader
-                id={goal.goalId}
-                title={goal.goalTitle}
-                color={goal.goalColor}
-              />
-              <ProgressLine percent={goal.progress} color={goal.goalColor} />
-              {goal.todos.map((todo) => (
-                <TodoList
-                  key={todo.todoId}
-                  todo={todo}
+          {goals.map((goal) => {
+            const todos = goal.todos.sort((a, b) =>
+              compareDates(b.endDate, a.endDate),
+            );
+
+            return (
+              <div
+                key={goal.goalId}
+                className="relative w-full rounded-12 bg-white p-16 shadow-sm"
+              >
+                <GoalHeader
+                  id={goal.goalId}
+                  title={goal.goalTitle}
                   color={goal.goalColor}
                 />
-              ))}
-            </div>
-          ))}
+                <ProgressLine percent={goal.progress} color={goal.goalColor} />
+                {todos.map((todo) => (
+                  <TodoList
+                    key={todo.todoId}
+                    todo={todo}
+                    color={goal.goalColor}
+                  />
+                ))}
+              </div>
+            );
+          })}
           {isFetchingNextPage && <Spinner />}
           <div ref={observerRef} style={{ height: '1px' }} />
         </div>

--- a/src/components/Goals/GoalList/index.tsx
+++ b/src/components/Goals/GoalList/index.tsx
@@ -5,6 +5,7 @@ import { TodoList } from '@/components/Dashboard/GoalList/GoalItem/TodoList';
 
 import { useGoalsDetailQuery } from '@/hooks/apis/Goals/useGoalsDetailQuery';
 
+import { EmptyStateText } from '@/components/common/EmptyStateText';
 import { Spinner } from '@/components/common/Spinner';
 import { GoalListSkeleon } from '@/components/Skeletons/GoalListSkeleton';
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
@@ -17,23 +18,28 @@ export const GoalList = () => {
 
   return (
     <div className="flex flex-col gap-16">
-      {isLoading && <GoalListSkeleon />}
-      {goals.map((goal) => (
-        <div
-          key={goal.goalId}
-          className="relative w-full rounded-12 bg-white p-16 shadow-sm"
-        >
-          <GoalHeader
-            id={goal.goalId}
-            title={goal.goalTitle}
-            color={goal.goalColor}
-          />
-          <ProgressLine percent={goal.progress} color={goal.goalColor} />
-          {goal.todos.map((todo) => (
-            <TodoList key={todo.todoId} todo={todo} color={goal.goalColor} />
-          ))}
-        </div>
-      ))}
+      {isLoading ? (
+        <GoalListSkeleon />
+      ) : goals.length > 0 ? (
+        goals.map((goal) => (
+          <div
+            key={goal.goalId}
+            className="relative w-full rounded-12 bg-white p-16 shadow-sm"
+          >
+            <GoalHeader
+              id={goal.goalId}
+              title={goal.goalTitle}
+              color={goal.goalColor}
+            />
+            <ProgressLine percent={goal.progress} color={goal.goalColor} />
+            {goal.todos.map((todo) => (
+              <TodoList key={todo.todoId} todo={todo} color={goal.goalColor} />
+            ))}
+          </div>
+        ))
+      ) : (
+        <EmptyStateText text="등록된 목표가 없습니다." />
+      )}
       {isFetchingNextPage && <Spinner />}
       <div ref={observerRef} style={{ height: '1px' }} />
     </div>

--- a/src/components/Skeletons/GoalListSkeleton/index.tsx
+++ b/src/components/Skeletons/GoalListSkeleton/index.tsx
@@ -1,0 +1,11 @@
+import { Skeleton } from '@/components/common/Skeleton';
+
+export const GoalListSkeleon = () => {
+  return (
+    <>
+      <Skeleton className="h-200 rounded-12" />
+      <Skeleton className="h-160 rounded-12" />
+      <Skeleton className="h-160 rounded-12" />
+    </>
+  );
+};

--- a/src/components/Skeletons/GoalListSkeleton/index.tsx
+++ b/src/components/Skeletons/GoalListSkeleton/index.tsx
@@ -2,10 +2,10 @@ import { Skeleton } from '@/components/common/Skeleton';
 
 export const GoalListSkeleon = () => {
   return (
-    <>
+    <div className="flex flex-col gap-16">
       <Skeleton className="h-200 rounded-12" />
       <Skeleton className="h-160 rounded-12" />
       <Skeleton className="h-160 rounded-12" />
-    </>
+    </div>
   );
 };

--- a/src/components/Skeletons/TodoListSkeleton/index.tsx
+++ b/src/components/Skeletons/TodoListSkeleton/index.tsx
@@ -1,0 +1,17 @@
+import { Skeleton } from '@/components/common/Skeleton';
+
+export const TodoListSkeleton = () => {
+  return (
+    <>
+      {Array.from({ length: 3 }, (_, index) => (
+        <div key={index} className="flex h-72">
+          <Skeleton className="my-8 size-56 rounded-16" />
+          <div className="ml-16 flex h-72 flex-col items-start justify-center gap-10">
+            <Skeleton className="h-12 w-40 rounded-16" />
+            <Skeleton className="h-20 w-120 rounded-16" />
+          </div>
+        </div>
+      ))}
+    </>
+  );
+};

--- a/src/components/common/EmptyStateText/index.tsx
+++ b/src/components/common/EmptyStateText/index.tsx
@@ -1,0 +1,14 @@
+import { cn } from '@/utils/className';
+
+interface EmptyStateTextProps {
+  text: string;
+  classNeme?: string;
+}
+
+export const EmptyStateText = ({ text, classNeme }: EmptyStateTextProps) => {
+  const textClass = cn(
+    'text-center !text-sm-normal text-custom-gray-200',
+    classNeme,
+  );
+  return <p className={textClass}>{text}</p>;
+};

--- a/src/components/common/NoDataText/index.tsx
+++ b/src/components/common/NoDataText/index.tsx
@@ -5,10 +5,11 @@ interface EmptyStateTextProps {
   classNeme?: string;
 }
 
-export const EmptyStateText = ({ text, classNeme }: EmptyStateTextProps) => {
+export const NoDataText = ({ text, classNeme }: EmptyStateTextProps) => {
   const textClass = cn(
-    'text-center !text-sm-normal text-custom-gray-200',
+    'text-center !text-sm-normal text-custom-gray-100',
     classNeme,
   );
+
   return <p className={textClass}>{text}</p>;
 };

--- a/src/components/common/Spinner/index.tsx
+++ b/src/components/common/Spinner/index.tsx
@@ -1,6 +1,10 @@
-export const Spinner = () => (
+interface SpinnerProps {
+  className?: string;
+}
+
+export const Spinner = ({ className }: SpinnerProps) => (
   <svg
-    className="size-12 animate-spin text-current"
+    className={`size-12 animate-spin text-current ${className}`}
     xmlns="http://www.w3.org/2000/svg"
     fill="none"
     viewBox="0 0 24 24"

--- a/src/constants/NoDataText.ts
+++ b/src/constants/NoDataText.ts
@@ -1,0 +1,5 @@
+export const NO_DATA_TEXT = {
+  NO_GOAL: '등록된 목표가 없습니다.',
+  NO_TODO: '등록된 할 일이 없습니다.',
+  NO_TODO_AND_GOAL: '목표 먼저 등록 후 할 일을 설정해주세요.',
+};

--- a/src/hooks/apis/Goals/useDeleteGoalMutation.ts
+++ b/src/hooks/apis/Goals/useDeleteGoalMutation.ts
@@ -15,6 +15,8 @@ export const useDeleteGoalMutation = () => {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.ALL_GOALS] });
       queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.GOALS] });
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.RECENT_TODOS] });
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.TODOS_OF_GOALS] });
       notify('success', '목표 삭제에 성공했습니다.', 3000);
     },
     onError: (error) => {

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -55,3 +55,10 @@ export const isDatePast = (dateString: string): boolean => {
 
   return today > thisDay;
 };
+
+export const compareDates = (a: string, b: string) => {
+  const dateA = new Date(a);
+  const dateB = new Date(b);
+
+  return dateA.getTime() - dateB.getTime();
+};


### PR DESCRIPTION
# 📄 무한 스크롤 스켈레톤 및 로딩 추가

## 📝 변경 사항 요약
- 무한 스크롤 스켈레톤 및 로딩 추가
- 할일 순서 및 정리
- 목표나 할일이 없을 경우 텍스트 정리

## 📌 관련 이슈
- 이슈 번호: #162 

## 🔍 변경 사항 상세 설명
### 무한 스크롤 스켈레톤 및 로딩 추가
무한 스크롤이 적용된 대시보드, 목표 페이지에 스켈레톤 적용 시켰습니다.
따로 `skeleton` 폴더에 정리해서 import 하는 방식으로 가져왔습니다.
스크롤해서 다음 데이터를 받아올 땐 스피너를 추가시켰습니다.

### 할일 순서 및 정리
목표 페이지에서 종료된 할일은 기간대신 종료라고 나오고 순서를 `endDate` 기준으로 정렬하였습니다.

### 목표나 할일이 없을 경우 텍스트 정리
목표나 할일이 없을 경우 나타나는 텍스트를 `NoDateText` 컴포넌트로 나타낼 수 있도록 했습니다.
`constants` 폴더 안에 텍스트 정의해서 사용했습니다.


## ✅ 확인 사항
- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 관련 테스트를 작성하고 모두 통과했는지 확인했습니다.
- [x] 코드 스타일 가이드에 맞게 작성했습니다.

## 📸 스크린샷 (선택 사항)

https://github.com/user-attachments/assets/5bd49a89-ce85-42fe-813b-cb3c6f1c05d1


## 기타 참고 사항
추가로 공유하고 싶은 내용이나 참고 자료가 있다면 여기에 작성해주세요.
