### PR TITLE
[Feat] 할일 상세보기 페이지 (퍼블리싱, 할일 데이터, 할일 삭제수정)

### DIFF
--- a/src/app/(route)/myPage/page.tsx
+++ b/src/app/(route)/myPage/page.tsx
@@ -1,13 +1,7 @@
-import type { Metadata } from 'next';
 import { Header } from '@/components/common/Header';
 import { MyProfile } from '@/components/MyPage/MyProfile';
 import { MyFollow } from '@/components/MyPage/MyFollow';
 import { MyPageSetting } from '@/components/MyPage/MyPageSetting';
-
-export const metadata: Metadata = {
-  title: 'My page',
-  description: 'My page',
-};
 
 export default function myPage() {
   return (

--- a/src/app/(route)/search/layout.tsx
+++ b/src/app/(route)/search/layout.tsx
@@ -1,10 +1,3 @@
-import type { Metadata } from 'next';
-
-export const metadata: Metadata = {
-  title: 'Search Users or Goals',
-  description: 'Search Page',
-};
-
 export default function RootLayout({
   children,
 }: Readonly<{

--- a/src/app/(route)/todos/[todoId]/layout.tsx
+++ b/src/app/(route)/todos/[todoId]/layout.tsx
@@ -1,0 +1,7 @@
+export default function RootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return <div className="flex">{children}</div>;
+}

--- a/src/app/(route)/todos/[todoId]/page.tsx
+++ b/src/app/(route)/todos/[todoId]/page.tsx
@@ -14,7 +14,7 @@ export default async function todoDetail({
 
   return (
     <div className="flex min-h-screen w-screen flex-col gap-16 bg-custom-white-100 p-16 md:px-200 xl:px-400 2xl:px-650">
-      <TodosDetailHeader />
+      <TodosDetailHeader todoId={todoId} />
       <TodosDetailContent todoId={todoId} />
     </div>
   );

--- a/src/app/(route)/todos/[todoId]/page.tsx
+++ b/src/app/(route)/todos/[todoId]/page.tsx
@@ -1,0 +1,21 @@
+import { TodosDetailContent } from '@/components/TodosDetail/TodosDetailContent';
+import { TodosDetailHeader } from '@/components/TodosDetail/TodosDetailHeader';
+
+interface TodoDetailProps {
+  todoId: string;
+}
+
+export default async function todoDetail({
+  params,
+}: {
+  params: Promise<TodoDetailProps>;
+}) {
+  const { todoId } = await params;
+
+  return (
+    <div className="flex min-h-screen w-screen flex-col gap-16 bg-custom-white-100 p-16 md:px-200 xl:px-400 2xl:px-650">
+      <TodosDetailHeader />
+      <TodosDetailContent todoId={todoId} />
+    </div>
+  );
+}

--- a/src/app/(route)/userProfile/[userId]/layout.tsx
+++ b/src/app/(route)/userProfile/[userId]/layout.tsx
@@ -1,10 +1,3 @@
-import type { Metadata } from 'next';
-
-export const metadata: Metadata = {
-  title: 'User Profile',
-  description: 'User Profile Page',
-};
-
 export default function RootLayout({
   children,
 }: Readonly<{

--- a/src/components/Todos/TodoItem.tsx
+++ b/src/components/Todos/TodoItem.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { FaCamera, FaCircleCheck } from 'react-icons/fa6';
 import Image from 'next/image';
+import { useRouter } from 'next/navigation';
 import { TodoCompletesResponse } from '@/hooks/apis/Todo/useTodayTodo';
 import { useVerificationNoteStore } from '@/store/useVerificationNoteStore';
 import { InputModalContent } from '../ImageInput';
@@ -18,10 +19,19 @@ interface TodoItemProps {
 }
 
 export const TodoItem = (props: TodoItemProps) => {
-  const { todoTitle, goalTitle, goalColor, complete, className = '' } = props;
+  const {
+    todoTitle,
+    goalTitle,
+    goalColor,
+    complete,
+    todoId,
+    className = '',
+  } = props;
 
   const [isGalleryModalOpen, setIsGalleryModalOpen] = useState(false);
   const [isCertifiedModalOpen, setIsCertifiedModalOpen] = useState(false);
+
+  const router = useRouter();
 
   const {
     setCompleteId,
@@ -88,7 +98,10 @@ export const TodoItem = (props: TodoItemProps) => {
             <FaCamera fill="white" />
           </div>
         )}
-        <div className="my-14 ml-16">
+        <div
+          className="my-14 ml-16"
+          onClick={() => router.push(`/todos/${todoId}`)}
+        >
           <div className="text-xs-medium text-custom-gray-100">{goalTitle}</div>
           <div className="text-base-medium text-custom-gray-300">
             {todoTitle}

--- a/src/components/TodosDetail/TodosDetailContent/TodoDocs/index.tsx
+++ b/src/components/TodosDetail/TodosDetailContent/TodoDocs/index.tsx
@@ -1,0 +1,32 @@
+import { useState } from 'react';
+import Image from 'next/image';
+import { FaLink } from 'react-icons/fa';
+
+export const TodoDocs = () => {
+  const [file] = useState('');
+  const [link] = useState('dd');
+
+  return (
+    <div className="flex flex-col gap-8">
+      {(file || link) && <span className="text-sm-semibold">첨부된 자료</span>}
+      {file && !link && (
+        <Image
+          width={340}
+          height={340}
+          className="w-full rounded-16"
+          priority
+          src="https://slid-todo.s3.ap-northeast-2.amazonaws.com/a19c4793-d33b-4be6-9f65-097bed5a6709_testmouse1.png"
+          alt="프로필 사진"
+        />
+      )}
+      {!file && link && (
+        <div className="flex items-center gap-8 rounded-8 bg-custom-white-200 p-12">
+          <FaLink className="size-24 shrink-0 cursor-pointer text-primary-100" />
+          <span className="truncate text-sm-normal text-custom-gray-100">
+            링크링크링크링크ddddddddddddddddddddddddddddddddddddddddddddddddddddddd
+          </span>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/TodosDetail/TodosDetailContent/TodoDocs/index.tsx
+++ b/src/components/TodosDetail/TodosDetailContent/TodoDocs/index.tsx
@@ -16,7 +16,7 @@ export const TodoDocs = ({ todoLink, todoPic }: TodoDocsProps) => {
         <Image
           width={340}
           height={340}
-          className="w-full rounded-16"
+          className="h-340 w-full rounded-16 object-cover"
           priority
           src={todoPic}
           alt="프로필 사진"

--- a/src/components/TodosDetail/TodosDetailContent/TodoDocs/index.tsx
+++ b/src/components/TodosDetail/TodosDetailContent/TodoDocs/index.tsx
@@ -1,15 +1,18 @@
-import { useState } from 'react';
 import Image from 'next/image';
 import { FaLink } from 'react-icons/fa';
 
-export const TodoDocs = () => {
-  const [file] = useState('');
-  const [link] = useState('dd');
+interface TodoDocsProps {
+  todoLink: string;
+  todoPic: string;
+}
 
+export const TodoDocs = ({ todoLink, todoPic }: TodoDocsProps) => {
   return (
     <div className="flex flex-col gap-8">
-      {(file || link) && <span className="text-sm-semibold">첨부된 자료</span>}
-      {file && !link && (
+      {(todoPic || todoLink) && (
+        <span className="text-sm-semibold">첨부된 자료</span>
+      )}
+      {todoPic && !todoLink && (
         <Image
           width={340}
           height={340}
@@ -19,7 +22,7 @@ export const TodoDocs = () => {
           alt="프로필 사진"
         />
       )}
-      {!file && link && (
+      {!todoPic && todoLink && (
         <div className="flex items-center gap-8 rounded-8 bg-custom-white-200 p-12">
           <FaLink className="size-24 shrink-0 cursor-pointer text-primary-100" />
           <span className="truncate text-sm-normal text-custom-gray-100">

--- a/src/components/TodosDetail/TodosDetailContent/TodoDocs/index.tsx
+++ b/src/components/TodosDetail/TodosDetailContent/TodoDocs/index.tsx
@@ -2,8 +2,8 @@ import Image from 'next/image';
 import { FaLink } from 'react-icons/fa';
 
 interface TodoDocsProps {
-  todoLink: string;
-  todoPic: string;
+  todoLink: string | undefined;
+  todoPic: string | undefined;
 }
 
 export const TodoDocs = ({ todoLink, todoPic }: TodoDocsProps) => {

--- a/src/components/TodosDetail/TodosDetailContent/TodoDocs/index.tsx
+++ b/src/components/TodosDetail/TodosDetailContent/TodoDocs/index.tsx
@@ -18,7 +18,7 @@ export const TodoDocs = ({ todoLink, todoPic }: TodoDocsProps) => {
           height={340}
           className="w-full rounded-16"
           priority
-          src="https://slid-todo.s3.ap-northeast-2.amazonaws.com/a19c4793-d33b-4be6-9f65-097bed5a6709_testmouse1.png"
+          src={todoPic}
           alt="프로필 사진"
         />
       )}
@@ -26,7 +26,7 @@ export const TodoDocs = ({ todoLink, todoPic }: TodoDocsProps) => {
         <div className="flex items-center gap-8 rounded-8 bg-custom-white-200 p-12">
           <FaLink className="size-24 shrink-0 cursor-pointer text-primary-100" />
           <span className="truncate text-sm-normal text-custom-gray-100">
-            링크링크링크링크ddddddddddddddddddddddddddddddddddddddddddddddddddddddd
+            {todoLink}
           </span>
         </div>
       )}

--- a/src/components/TodosDetail/TodosDetailContent/TodoProfile/index.tsx
+++ b/src/components/TodosDetail/TodosDetailContent/TodoProfile/index.tsx
@@ -1,0 +1,18 @@
+import { FaCamera } from 'react-icons/fa6';
+
+export const TodoProfile = () => {
+  return (
+    <div className="flex items-center gap-16">
+      <div
+        className="flex-center my-8 size-56 cursor-pointer rounded-16"
+        style={{ backgroundColor: 'black' }} //goalColor
+      >
+        <FaCamera fill="white" />
+      </div>
+      <div className="flex flex-col items-start">
+        <span className="text-xs-medium text-custom-gray-100">dfdfdf</span>
+        <span className="text-base-medium">dfdfdf</span>
+      </div>
+    </div>
+  );
+};

--- a/src/components/TodosDetail/TodosDetailContent/TodoProfile/index.tsx
+++ b/src/components/TodosDetail/TodosDetailContent/TodoProfile/index.tsx
@@ -15,7 +15,7 @@ export const TodoProfile = ({
     <div className="flex items-center gap-16">
       <div
         className="flex-center my-8 size-56 cursor-pointer rounded-16"
-        style={{ backgroundColor: goalColor }} //goalColor
+        style={{ backgroundColor: goalColor }}
       >
         <FaCamera fill="white" />
       </div>

--- a/src/components/TodosDetail/TodosDetailContent/TodoProfile/index.tsx
+++ b/src/components/TodosDetail/TodosDetailContent/TodoProfile/index.tsx
@@ -1,9 +1,9 @@
 import { FaCamera } from 'react-icons/fa6';
 
 interface TodoProfileProps {
-  goalColor: string;
-  goalTitle: string;
-  todoTitle: string;
+  goalColor: string | undefined;
+  goalTitle: string | undefined;
+  todoTitle: string | undefined;
 }
 
 export const TodoProfile = ({

--- a/src/components/TodosDetail/TodosDetailContent/TodoProfile/index.tsx
+++ b/src/components/TodosDetail/TodosDetailContent/TodoProfile/index.tsx
@@ -1,17 +1,27 @@
 import { FaCamera } from 'react-icons/fa6';
 
-export const TodoProfile = () => {
+interface TodoProfileProps {
+  goalColor: string;
+  goalTitle: string;
+  todoTitle: string;
+}
+
+export const TodoProfile = ({
+  goalColor,
+  goalTitle,
+  todoTitle,
+}: TodoProfileProps) => {
   return (
     <div className="flex items-center gap-16">
       <div
         className="flex-center my-8 size-56 cursor-pointer rounded-16"
-        style={{ backgroundColor: 'black' }} //goalColor
+        style={{ backgroundColor: goalColor }} //goalColor
       >
         <FaCamera fill="white" />
       </div>
       <div className="flex flex-col items-start">
-        <span className="text-xs-medium text-custom-gray-100">dfdfdf</span>
-        <span className="text-base-medium">dfdfdf</span>
+        <span className="text-xs-medium text-custom-gray-100">{goalTitle}</span>
+        <span className="text-base-medium">{todoTitle}</span>
       </div>
     </div>
   );

--- a/src/components/TodosDetail/TodosDetailContent/TodoRepeat/index.tsx
+++ b/src/components/TodosDetail/TodosDetailContent/TodoRepeat/index.tsx
@@ -1,14 +1,19 @@
-export const TodoRepeat = () => {
+interface TodoRepeatProps {
+  startDate: string;
+  endDate: string;
+}
+
+export const TodoRepeat = ({ startDate, endDate }: TodoRepeatProps) => {
   return (
     <div className="flex w-full flex-col gap-8">
       <span className="text-base-semibold">기간</span>
       <div className="flex w-full items-center gap-8">
         <div className="flex w-full  justify-center rounded-12 bg-white px-16 py-12 text-sm-medium">
-          24.12.13
+          {startDate}
         </div>
         <span className="text-sm-medium">~</span>
         <div className="flex w-full justify-center rounded-12 bg-white px-16 py-12 text-sm-medium">
-          24.12.20
+          {endDate}
         </div>
       </div>
     </div>

--- a/src/components/TodosDetail/TodosDetailContent/TodoRepeat/index.tsx
+++ b/src/components/TodosDetail/TodosDetailContent/TodoRepeat/index.tsx
@@ -1,6 +1,6 @@
 interface TodoRepeatProps {
-  startDate: string;
-  endDate: string;
+  startDate: string | undefined;
+  endDate: string | undefined;
 }
 
 export const TodoRepeat = ({ startDate, endDate }: TodoRepeatProps) => {

--- a/src/components/TodosDetail/TodosDetailContent/TodoRepeat/index.tsx
+++ b/src/components/TodosDetail/TodosDetailContent/TodoRepeat/index.tsx
@@ -1,0 +1,16 @@
+export const TodoRepeat = () => {
+  return (
+    <div className="flex w-full flex-col gap-8">
+      <span className="text-base-semibold">기간</span>
+      <div className="flex w-full items-center gap-8">
+        <div className="flex w-full  justify-center rounded-12 bg-white px-16 py-12 text-sm-medium">
+          24.12.13
+        </div>
+        <span className="text-sm-medium">~</span>
+        <div className="flex w-full justify-center rounded-12 bg-white px-16 py-12 text-sm-medium">
+          24.12.20
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/TodosDetail/TodosDetailContent/index.tsx
+++ b/src/components/TodosDetail/TodosDetailContent/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useTodoDetailQuery } from '@/hooks/apis/Todo/useTodoDetailQuery';
+import { Spinner } from '@/components/common/Spinner';
 import { TodoTypes } from '@/types/data';
 import { TodoDocs } from './TodoDocs';
 import { TodoProfile } from './TodoProfile';
@@ -11,9 +12,18 @@ interface TodosDetailContentProps {
 }
 
 export const TodosDetailContent = ({ todoId }: TodosDetailContentProps) => {
-  const { details } = useTodoDetailQuery(Number(todoId)) as {
+  const { details, isLoading } = useTodoDetailQuery(Number(todoId)) as {
     details: TodoTypes;
+    isLoading: boolean;
   };
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <Spinner className="size-28" />
+      </div>
+    );
+  }
 
   return (
     <div className="flex flex-col gap-16">

--- a/src/components/TodosDetail/TodosDetailContent/index.tsx
+++ b/src/components/TodosDetail/TodosDetailContent/index.tsx
@@ -2,7 +2,6 @@
 
 import { useTodoDetailQuery } from '@/hooks/apis/Todo/useTodoDetailQuery';
 import { Spinner } from '@/components/common/Spinner';
-import { TodoTypes } from '@/types/data';
 import { TodoDocs } from './TodoDocs';
 import { TodoProfile } from './TodoProfile';
 import { TodoRepeat } from './TodoRepeat';
@@ -12,10 +11,7 @@ interface TodosDetailContentProps {
 }
 
 export const TodosDetailContent = ({ todoId }: TodosDetailContentProps) => {
-  const { details, isLoading } = useTodoDetailQuery(Number(todoId)) as {
-    details: TodoTypes;
-    isLoading: boolean;
-  };
+  const { details, isLoading } = useTodoDetailQuery(Number(todoId));
 
   if (isLoading) {
     return (
@@ -28,12 +24,12 @@ export const TodosDetailContent = ({ todoId }: TodosDetailContentProps) => {
   return (
     <div className="flex flex-col gap-16">
       <TodoProfile
-        goalColor={details.goalColor}
-        goalTitle={details.goalTitle}
-        todoTitle={details.todoTitle}
+        goalColor={details?.goalColor}
+        goalTitle={details?.goalTitle}
+        todoTitle={details?.todoTitle}
       />
-      <TodoRepeat startDate={details.startDate} endDate={details.endDate} />
-      <TodoDocs todoLink={details.todoLink} todoPic={details.todoPic} />
+      <TodoRepeat startDate={details?.startDate} endDate={details?.endDate} />
+      <TodoDocs todoLink={details?.todoLink} todoPic={details?.todoPic} />
     </div>
   );
 };

--- a/src/components/TodosDetail/TodosDetailContent/index.tsx
+++ b/src/components/TodosDetail/TodosDetailContent/index.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useTodoDetailQuery } from '@/hooks/apis/Todo/useTodoDetailQuery';
+import { Spinner } from '@/components/common/Spinner';
 import { TodoDocs } from './TodoDocs';
 import { TodoProfile } from './TodoProfile';
 import { TodoRepeat } from './TodoRepeat';
@@ -9,13 +11,29 @@ interface TodosDetailContentProps {
 }
 
 export const TodosDetailContent = ({ todoId }: TodosDetailContentProps) => {
-  console.log(todoId);
+  const { details, isLoading } = useTodoDetailQuery(Number(todoId));
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <Spinner className="size-28" />
+      </div>
+    );
+  }
+
+  if (!details || Array.isArray(details)) {
+    return <div>Error loading todo details</div>;
+  }
 
   return (
     <div className="flex flex-col gap-16">
-      <TodoProfile />
-      <TodoRepeat />
-      <TodoDocs />
+      <TodoProfile
+        goalColor={details.goalColor}
+        goalTitle={details.goalTitle}
+        todoTitle={details.todoTitle}
+      />
+      <TodoRepeat startDate={details.startDate} endDate={details.endDate} />
+      <TodoDocs todoLink={details.todoLink} todoPic={details.todoPic} />
     </div>
   );
 };

--- a/src/components/TodosDetail/TodosDetailContent/index.tsx
+++ b/src/components/TodosDetail/TodosDetailContent/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useTodoDetailQuery } from '@/hooks/apis/Todo/useTodoDetailQuery';
-import { Spinner } from '@/components/common/Spinner';
+import { TodoTypes } from '@/types/data';
 import { TodoDocs } from './TodoDocs';
 import { TodoProfile } from './TodoProfile';
 import { TodoRepeat } from './TodoRepeat';
@@ -11,19 +11,9 @@ interface TodosDetailContentProps {
 }
 
 export const TodosDetailContent = ({ todoId }: TodosDetailContentProps) => {
-  const { details, isLoading } = useTodoDetailQuery(Number(todoId));
-
-  if (isLoading) {
-    return (
-      <div className="flex min-h-screen items-center justify-center">
-        <Spinner className="size-28" />
-      </div>
-    );
-  }
-
-  if (!details || Array.isArray(details)) {
-    return <div>Error loading todo details</div>;
-  }
+  const { details } = useTodoDetailQuery(Number(todoId)) as {
+    details: TodoTypes;
+  };
 
   return (
     <div className="flex flex-col gap-16">

--- a/src/components/TodosDetail/TodosDetailContent/index.tsx
+++ b/src/components/TodosDetail/TodosDetailContent/index.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { TodoDocs } from './TodoDocs';
+import { TodoProfile } from './TodoProfile';
+import { TodoRepeat } from './TodoRepeat';
+
+interface TodosDetailContentProps {
+  todoId: string;
+}
+
+export const TodosDetailContent = ({ todoId }: TodosDetailContentProps) => {
+  console.log(todoId);
+
+  return (
+    <div className="flex flex-col gap-16">
+      <TodoProfile />
+      <TodoRepeat />
+      <TodoDocs />
+    </div>
+  );
+};

--- a/src/components/TodosDetail/TodosDetailHeader/index.tsx
+++ b/src/components/TodosDetail/TodosDetailHeader/index.tsx
@@ -1,14 +1,62 @@
 'use client';
 
+import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { IoMdClose } from 'react-icons/io';
 import { FaEllipsisVertical } from 'react-icons/fa6';
+import { useTodoDetailQuery } from '@/hooks/apis/Todo/useTodoDetailQuery';
+import { useTodoModalStore } from '@/store/useTodoModalStore';
+import { useTodoDataStore } from '@/store/useTodoDataStore';
+import { TodoTypes } from '@/types/data';
+import { convertImageToBase64 } from '@/apis/Todo/convertImageToBase64';
+import { useDeleteTodo } from '@/hooks/apis/Todo/useDeleteTodo';
 
-export const TodosDetailHeader = () => {
+interface TodosDetailHeaderProps {
+  todoId: string;
+}
+
+export const TodosDetailHeader = ({ todoId }: TodosDetailHeaderProps) => {
+  const [isOpenTab, setIsOpenTab] = useState(false);
+
   const router = useRouter();
+  const { details } = useTodoDetailQuery(Number(todoId)) as {
+    details: TodoTypes;
+  };
+  const { open } = useTodoModalStore();
+  const { setTodoData } = useTodoDataStore();
+  const { mutate: deleteTodo } = useDeleteTodo();
 
   const handleBack = () => {
     router.back();
+  };
+
+  const handleClick = () => {
+    setIsOpenTab(!isOpenTab);
+  };
+
+  const handleOpenModify = async () => {
+    let imageUrl: string | undefined = undefined;
+
+    if (details.todoPic) {
+      imageUrl = await convertImageToBase64(details.todoPic);
+    }
+
+    setTodoData({
+      todoId: Number(todoId),
+      title: details.todoTitle,
+      startDate: details.startDate,
+      endDate: details.endDate,
+      todoStatus: details.todoStatus,
+      todoLink: details.todoLink,
+      imageEncodedBase64: imageUrl,
+      goalTitle: details.goalTitle,
+    });
+    open('수정');
+    setIsOpenTab(false);
+  };
+
+  const handleDelete = () => {
+    deleteTodo({ todoId: Number(todoId) });
   };
 
   return (
@@ -17,7 +65,26 @@ export const TodosDetailHeader = () => {
         <IoMdClose className="size-24 cursor-pointer" onClick={handleBack} />
         <span className="text-xl-semibold">할 일 상세보기</span>
       </div>
-      <FaEllipsisVertical className="size-24 p-2 text-custom-gray-100" />
+      <FaEllipsisVertical
+        className="relative size-24 p-2 text-custom-gray-100"
+        onClick={handleClick}
+      />
+      {isOpenTab && (
+        <div className="absolute right-16 top-48 flex flex-col rounded-12 bg-white">
+          <div
+            className="flex-center cursor-pointer rounded-t-12 px-16 py-8 text-sm-normal hover:bg-custom-white-200"
+            onClick={handleOpenModify}
+          >
+            수정하기
+          </div>
+          <div
+            className="flex-center cursor-pointer rounded-b-12 px-16 py-8 text-sm-normal hover:bg-custom-white-200"
+            onClick={handleDelete}
+          >
+            삭제하기
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/TodosDetail/TodosDetailHeader/index.tsx
+++ b/src/components/TodosDetail/TodosDetailHeader/index.tsx
@@ -46,6 +46,7 @@ export const TodosDetailHeader = ({ todoId }: TodosDetailHeaderProps) => {
       todoStatus: details?.todoStatus,
       todoLink: details?.todoLink,
       imageEncodedBase64: imageUrl,
+      imageName: details?.todoPicName,
       goalTitle: details?.goalTitle,
     });
     open('수정');

--- a/src/components/TodosDetail/TodosDetailHeader/index.tsx
+++ b/src/components/TodosDetail/TodosDetailHeader/index.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { IoMdClose } from 'react-icons/io';
+import { FaEllipsisVertical } from 'react-icons/fa6';
+
+export const TodosDetailHeader = () => {
+  const router = useRouter();
+
+  const handleBack = () => {
+    router.back();
+  };
+
+  return (
+    <div className="flex items-center justify-between">
+      <div className="flex items-center gap-16">
+        <IoMdClose className="size-24 cursor-pointer" onClick={handleBack} />
+        <span className="text-xl-semibold">할 일 상세보기</span>
+      </div>
+      <FaEllipsisVertical className="size-24 p-2 text-custom-gray-100" />
+    </div>
+  );
+};

--- a/src/components/TodosDetail/TodosDetailHeader/index.tsx
+++ b/src/components/TodosDetail/TodosDetailHeader/index.tsx
@@ -7,7 +7,6 @@ import { FaEllipsisVertical } from 'react-icons/fa6';
 import { useTodoDetailQuery } from '@/hooks/apis/Todo/useTodoDetailQuery';
 import { useTodoModalStore } from '@/store/useTodoModalStore';
 import { useTodoDataStore } from '@/store/useTodoDataStore';
-import { TodoTypes } from '@/types/data';
 import { convertImageToBase64 } from '@/apis/Todo/convertImageToBase64';
 import { useDeleteTodo } from '@/hooks/apis/Todo/useDeleteTodo';
 
@@ -19,9 +18,7 @@ export const TodosDetailHeader = ({ todoId }: TodosDetailHeaderProps) => {
   const [isOpenTab, setIsOpenTab] = useState(false);
 
   const router = useRouter();
-  const { details } = useTodoDetailQuery(Number(todoId)) as {
-    details: TodoTypes;
-  };
+  const { details } = useTodoDetailQuery(Number(todoId));
   const { open } = useTodoModalStore();
   const { setTodoData } = useTodoDataStore();
   const { mutate: deleteTodo } = useDeleteTodo();
@@ -37,19 +34,19 @@ export const TodosDetailHeader = ({ todoId }: TodosDetailHeaderProps) => {
   const handleOpenModify = async () => {
     let imageUrl: string | undefined = undefined;
 
-    if (details.todoPic) {
+    if (details?.todoPic) {
       imageUrl = await convertImageToBase64(details.todoPic);
     }
 
     setTodoData({
       todoId: Number(todoId),
-      title: details.todoTitle,
-      startDate: details.startDate,
-      endDate: details.endDate,
-      todoStatus: details.todoStatus,
-      todoLink: details.todoLink,
+      title: details?.todoTitle,
+      startDate: details?.startDate,
+      endDate: details?.endDate,
+      todoStatus: details?.todoStatus,
+      todoLink: details?.todoLink,
       imageEncodedBase64: imageUrl,
-      goalTitle: details.goalTitle,
+      goalTitle: details?.goalTitle,
     });
     open('수정');
     setIsOpenTab(false);

--- a/src/constants/ApiEndpoints.ts
+++ b/src/constants/ApiEndpoints.ts
@@ -11,6 +11,7 @@ export const API_ENDPOINTS = {
     GET_TODAY_TODOS: '/api/v1/todos/today',
     PUT_CERTIFIED_TODO: (completeId: number) =>
       `/api/v1/completes/${completeId}`,
+    GET_DETAIL: (todoId: number) => `/api/v1/todos/${todoId}`,
   },
 
   AUTH: {

--- a/src/constants/QueryKeys.ts
+++ b/src/constants/QueryKeys.ts
@@ -11,4 +11,5 @@ export const QUERY_KEYS = {
   CERTIFIED_RECENT_TODO: 'certifiedRecentTodo',
   FOLLOW_COUNT: 'followCount',
   FOLLOWS: 'follows',
+  TODOS_DETAIL: 'todosDetail',
 };

--- a/src/hooks/apis/Todo/useDeleteTodo.ts
+++ b/src/hooks/apis/Todo/useDeleteTodo.ts
@@ -4,6 +4,7 @@ import {
   useQueryClient,
 } from '@tanstack/react-query';
 import { AxiosError, AxiosResponse } from 'axios';
+import { useRouter } from 'next/navigation';
 import { notify } from '@/store/useToastStore';
 import { QUERY_KEYS } from '@/constants/QueryKeys';
 import { deleteTodo } from '@/apis/Todo/deleteTodo';
@@ -19,12 +20,16 @@ export const useDeleteTodo = (): UseMutationResult<
 > => {
   const queryClient = useQueryClient();
 
+  const router = useRouter();
+
   return useMutation<AxiosResponse, AxiosError, DeleteMutationProps>({
     mutationFn: ({ todoId }: DeleteMutationProps) => deleteTodo(todoId),
     onSuccess: () => {
       notify('success', '삭제에 성공하였습니다', 3000);
+      router.push('/todos');
       queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.TODOS_OF_GOALS] });
       queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.RECENT_TODOS] });
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.TODAY_TODO] });
     },
     onError: (error: AxiosError) => {
       notify('error', '삭제에 실패하였습니다', 3000);

--- a/src/hooks/apis/Todo/useModifyTodo.ts
+++ b/src/hooks/apis/Todo/useModifyTodo.ts
@@ -32,6 +32,8 @@ export const useModifyTodo = (): UseMutationResult<
       notify('success', '수정에 성공하였습니다', 3000);
       queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.TODOS_OF_GOALS] });
       queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.RECENT_TODOS] });
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.TODAY_TODO] });
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.TODOS_DETAIL] });
       close();
       resetAll();
     },

--- a/src/hooks/apis/Todo/useTodoDetailQuery.ts
+++ b/src/hooks/apis/Todo/useTodoDetailQuery.ts
@@ -17,7 +17,7 @@ export const useTodoDetailQuery = (todoId: number) => {
   const { data, isLoading, error, isError } = useQuery(
     todoDetailOptions(todoId),
   );
-  const details = data?.data ?? [];
+  const details = data?.data;
 
   return { details, isLoading, error, isError };
 };

--- a/src/hooks/apis/Todo/useTodoDetailQuery.ts
+++ b/src/hooks/apis/Todo/useTodoDetailQuery.ts
@@ -1,0 +1,23 @@
+import { useQuery, UseQueryOptions } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+import { GET } from '@/apis/services/httpMethod';
+import { API_ENDPOINTS } from '@/constants/ApiEndpoints';
+import { QUERY_KEYS } from '@/constants/QueryKeys';
+import { TodoDetailResponse } from '@/types/response';
+
+const todoDetailOptions = (
+  todoId: number,
+): UseQueryOptions<TodoDetailResponse, AxiosError> => ({
+  queryKey: [QUERY_KEYS.TODOS_DETAIL, todoId],
+  queryFn: () =>
+    GET<TodoDetailResponse>(API_ENDPOINTS.TODOS.GET_DETAIL(todoId)),
+});
+
+export const useTodoDetailQuery = (todoId: number) => {
+  const { data, isLoading, error, isError } = useQuery(
+    todoDetailOptions(todoId),
+  );
+  const details = data?.data ?? [];
+
+  return { details, isLoading, error, isError };
+};

--- a/src/types/data.ts
+++ b/src/types/data.ts
@@ -44,3 +44,7 @@ export interface ContentTypes {
   likeCount: number;
   commentCount: number;
 }
+
+export interface TodoDetailTypes extends TodoTypes {
+  todoPicName: string;
+}

--- a/src/types/response.ts
+++ b/src/types/response.ts
@@ -1,4 +1,4 @@
-import { GoalTypes, ProgressTypes, TodoTypes } from './data';
+import { GoalTypes, ProgressTypes, TodoDetailTypes, TodoTypes } from './data';
 import { BasePageableTypes } from './pageable';
 
 export interface BaseResponse {
@@ -48,5 +48,5 @@ export interface WithdrawalResponse extends BaseResponse {
 }
 
 export interface TodoDetailResponse extends BaseResponse {
-  data: TodoTypes;
+  data: TodoDetailTypes;
 }

--- a/src/types/response.ts
+++ b/src/types/response.ts
@@ -46,3 +46,7 @@ export interface WithdrawalResponse extends BaseResponse {
     userId: number;
   };
 }
+
+export interface TodoDetailResponse extends BaseResponse {
+  data: TodoTypes;
+}


### PR DESCRIPTION
# 📄 할일 상세보기 페이지 (퍼블리싱, 할일 데이터, 할일 삭제수정)

## 📝 변경 사항 요약
- 할일 상세보기 페이지 퍼블리싱
- todos 페이지에서 할일을 클릭하면 해당 todos/todoId 페이지로 이동하도록
- 할일 상세보기 데이터 get 커스텀 훅
- 할일 삭제 / 수정 로직 적용

## 📌 관련 이슈
- 이슈 번호: #165

## 🔍 변경 사항 상세 설명
할일 삭제 / 수정 로직 적용
- zustand를 사용하여 수정 시 todoId 포함 할일 상세 데이터들의 값을 저장하도록 했습니다.
-  수정/삭제 클릭 시 커스텀훅 적용

## ✅ 확인 사항
- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 관련 테스트를 작성하고 모두 통과했는지 확인했습니다.
- [x] 코드 스타일 가이드에 맞게 작성했습니다.

## 📸 스크린샷 (선택 사항)
![상세 페이지 Gif](https://github.com/user-attachments/assets/95913fc7-5907-40cc-8f78-fdd456300567)


## 기타 참고 사항
머지는 api가 변경되면 하도록 하겠습니다.
