### PR TITLE
[Feat] 타인 프로필 페이지 (데이터 불러오기, 팔로우 기능)

### DIFF
--- a/src/apis/services/httpMethod.ts
+++ b/src/apis/services/httpMethod.ts
@@ -9,7 +9,7 @@ export async function GET<T>(url: string): Promise<T> {
   }
 }
 
-export async function POST<T, U>(url: string, data: U): Promise<T> {
+export async function POST<T, U>(url: string, data?: U): Promise<T> {
   try {
     const response = await axiosInstance.post(url, data);
     return response.data;

--- a/src/app/(route)/userProfile/[userId]/page.tsx
+++ b/src/app/(route)/userProfile/[userId]/page.tsx
@@ -14,7 +14,7 @@ export default async function userProfile({
   return (
     <div className="flex min-h-screen w-screen flex-col gap-16 bg-custom-white-100 p-16 md:px-200 xl:px-400 2xl:px-650">
       <UserProfileHeader userId={userId} />
-      <UserProfileContent />
+      <UserProfileContent userId={userId} />
     </div>
   );
 }

--- a/src/components/Search/SearchContent/SearchGoalList/index.tsx
+++ b/src/components/Search/SearchContent/SearchGoalList/index.tsx
@@ -1,4 +1,5 @@
 import { AxiosError } from 'axios';
+import { useRouter } from 'next/navigation';
 import Image from 'next/image';
 import { FaFlag } from 'react-icons/fa6';
 import { Goal } from '@/types/Goals';
@@ -17,6 +18,12 @@ export const SearchGoalList = ({
   searchData,
   keyword,
 }: SearchGoalListProps) => {
+  const router = useRouter();
+
+  const handleClickProfile = (userId: number) => {
+    router.push(`/userProfile/${userId}`);
+  };
+
   return (
     <ul className="flex flex-col gap-16">
       {isError ? (
@@ -26,7 +33,10 @@ export const SearchGoalList = ({
       ) : (
         searchData?.data.map((item: SearchResponseData) => (
           <li className="flex w-full flex-col" key={item.userId}>
-            <div className="flex w-full items-center gap-8">
+            <div
+              className="flex w-full items-center gap-8"
+              onClick={() => handleClickProfile(item.userId)}
+            >
               <Image
                 width={48}
                 height={48}

--- a/src/components/Search/SearchContent/SearchUserList/index.tsx
+++ b/src/components/Search/SearchContent/SearchUserList/index.tsx
@@ -1,4 +1,5 @@
 import { AxiosError } from 'axios';
+import { useRouter } from 'next/navigation';
 import Image from 'next/image';
 import { SearchResponseData } from '@/hooks/apis/Search/useSearchQuery';
 
@@ -15,6 +16,12 @@ export const SearchUserList = ({
   searchData,
   keyword,
 }: SearchUserListProps) => {
+  const router = useRouter();
+
+  const handleClickProfile = (userId: number) => {
+    router.push(`/userProfile/${userId}`);
+  };
+
   return (
     <ul className="flex flex-col gap-16">
       {isError ? (
@@ -23,7 +30,11 @@ export const SearchUserList = ({
         </div>
       ) : (
         searchData?.data.map((item: SearchResponseData) => (
-          <li className="flex w-full items-center gap-8" key={item.userId}>
+          <li
+            className="flex w-full items-center gap-8"
+            key={item.userId}
+            onClick={() => handleClickProfile(item.userId)}
+          >
             <Image
               width={48}
               height={48}

--- a/src/components/UserProfile/UserProfileContent/index.tsx
+++ b/src/components/UserProfile/UserProfileContent/index.tsx
@@ -11,31 +11,33 @@ interface UserProfileContent {
 export const UserProfileContent = ({ userId }: UserProfileContent) => {
   const { completeResponses, isLoading } = useUserProfileQuery(Number(userId));
 
+  if (isLoading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <Spinner className="size-28" />
+      </div>
+    );
+  }
+
   return (
     <div className="mt-8 grid grid-cols-3 gap-8">
-      {isLoading ? (
-        <div className="col-span-3 flex items-center justify-center">
-          <Spinner />
-        </div>
-      ) : (
-        completeResponses.map((complete) =>
-          complete.completePic ? (
-            <Image
-              key={complete.completeId}
-              width={48}
-              height={48}
-              className="flex h-109 w-full rounded-4"
-              priority
-              src={complete.completePic}
-              alt="인증한 이미지"
-            />
-          ) : (
-            <div
-              key={complete.completeId}
-              className="flex h-109 w-full rounded-4 bg-gray-200"
-            />
-          ),
-        )
+      {completeResponses.map((complete) =>
+        complete.completePic ? (
+          <Image
+            key={complete.completeId}
+            width={48}
+            height={48}
+            className="flex h-109 w-full rounded-4"
+            priority
+            src={complete.completePic}
+            alt="인증한 이미지"
+          />
+        ) : (
+          <div
+            key={complete.completeId}
+            className="flex h-109 w-full rounded-4 bg-gray-200"
+          />
+        ),
       )}
     </div>
   );

--- a/src/components/UserProfile/UserProfileContent/index.tsx
+++ b/src/components/UserProfile/UserProfileContent/index.tsx
@@ -1,25 +1,42 @@
-import Image from 'next/image';
+'use client';
 
-export const UserProfileContent = () => {
-  const images = Array.from({ length: 10 }, (_, index) => ({
-    id: index,
-    src: 'https://slid-todo.s3.ap-northeast-2.amazonaws.com/a19c4793-d33b-4be6-9f65-097bed5a6709_testmouse1.png',
-    alt: `프로필 사진 ${index + 1}`,
-  }));
+import Image from 'next/image';
+import { useUserProfileQuery } from '@/hooks/apis/Auth/useUserProfileQuery';
+import { Spinner } from '@/components/common/Spinner';
+
+interface UserProfileContent {
+  userId: string;
+}
+
+export const UserProfileContent = ({ userId }: UserProfileContent) => {
+  const { completeResponses, isLoading } = useUserProfileQuery(Number(userId));
 
   return (
     <div className="mt-8 grid grid-cols-3 gap-8">
-      {images.map((image) => (
-        <Image
-          key={image.id}
-          width={48}
-          height={48}
-          className="flex h-109 w-full rounded-4"
-          priority
-          src={image.src}
-          alt={image.alt}
-        />
-      ))}
+      {isLoading ? (
+        <div className="col-span-3 flex items-center justify-center">
+          <Spinner />
+        </div>
+      ) : (
+        completeResponses.map((complete) =>
+          complete.completePic ? (
+            <Image
+              key={complete.completeId}
+              width={48}
+              height={48}
+              className="flex h-109 w-full rounded-4"
+              priority
+              src={complete.completePic}
+              alt="인증한 이미지"
+            />
+          ) : (
+            <div
+              key={complete.completeId}
+              className="flex h-109 w-full rounded-4 bg-gray-200"
+            />
+          ),
+        )
+      )}
     </div>
   );
 };

--- a/src/components/UserProfile/UserProfileHeader/index.tsx
+++ b/src/components/UserProfile/UserProfileHeader/index.tsx
@@ -5,8 +5,8 @@ import { useRouter } from 'next/navigation';
 import Image from 'next/image';
 import { Button } from '@/components/common/Button/Button';
 import { useUserProfileQuery } from '@/hooks/apis/Auth/useUserProfileQuery';
-// import { useAssignFollowMutation } from '@/hooks/apis/Follow/useAssignFollowMutation';
-// import { useDeleteFollowMutation } from '@/hooks/apis/Follow/useDeleteFollowMutation';
+import { useAssignFollowMutation } from '@/hooks/apis/Follow/useAssignFollowMutation';
+import { useDeleteFollowMutation } from '@/hooks/apis/Follow/useDeleteFollowMutation';
 
 interface UserProfileHeader {
   userId: string;
@@ -16,8 +16,8 @@ export const UserProfileHeader = ({ userId }: UserProfileHeader) => {
   const router = useRouter();
 
   const { name, profilePic, isFollow } = useUserProfileQuery(Number(userId));
-  // const { mutate: assignFollow, isPending } = useAssignFollowMutation();
-  // const { mutate: deleteFollow } = useDeleteFollowMutation();
+  const { mutate: assignFollow } = useAssignFollowMutation();
+  const { mutate: deleteFollow } = useDeleteFollowMutation();
 
   const handleBack = () => {
     router.back();
@@ -25,10 +25,9 @@ export const UserProfileHeader = ({ userId }: UserProfileHeader) => {
 
   const handleClickFollow = () => {
     if (isFollow) {
-      console.log('dddd');
+      deleteFollow(Number(userId));
     } else {
-      //assignFollow(Number(userId));
-      //deleteFollow(Number(userId));
+      assignFollow(Number(userId));
     }
   };
 
@@ -53,9 +52,8 @@ export const UserProfileHeader = ({ userId }: UserProfileHeader) => {
           size="small"
           primary={isFollow ? false : true}
           onClick={handleClickFollow}
-          // pending={isPending}
         >
-          {isFollow ? '팔로우' : '팔로잉'}
+          {isFollow === true ? '팔로잉' : '팔로우'}
         </Button>
       </div>
     </>

--- a/src/components/UserProfile/UserProfileHeader/index.tsx
+++ b/src/components/UserProfile/UserProfileHeader/index.tsx
@@ -4,6 +4,7 @@ import { IoMdClose } from 'react-icons/io';
 import { useRouter } from 'next/navigation';
 import Image from 'next/image';
 import { Button } from '@/components/common/Button/Button';
+import { useUserProfileQuery } from '@/hooks/apis/Auth/useUserProfileQuery';
 
 interface UserProfileHeader {
   userId: string;
@@ -11,6 +12,8 @@ interface UserProfileHeader {
 
 export const UserProfileHeader = ({ userId }: UserProfileHeader) => {
   const router = useRouter();
+
+  const { name, profilePic, isFollow } = useUserProfileQuery(Number(userId));
 
   const handleBack = () => {
     router.back();
@@ -21,18 +24,20 @@ export const UserProfileHeader = ({ userId }: UserProfileHeader) => {
       <IoMdClose className="size-24 cursor-pointer" onClick={handleBack} />
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-8">
-          <Image
-            width={48}
-            height={48}
-            className="flex size-64 rounded-full"
-            priority
-            src="https://slid-todo.s3.ap-northeast-2.amazonaws.com/a19c4793-d33b-4be6-9f65-097bed5a6709_testmouse1.png"
-            alt="프로필 사진"
-          />
-          <span className="text-base-medium">체다치즈 {userId}</span>
+          {profilePic ? (
+            <Image
+              width={48}
+              height={48}
+              className="flex size-64 rounded-full"
+              priority
+              src={profilePic}
+              alt={name ? `${name}의 프로필 사진` : '프로필 사진'}
+            />
+          ) : null}
+          <span className="text-base-medium">{name}</span>
         </div>
-        <Button size="small" primary={false}>
-          팔로우
+        <Button size="small" primary={isFollow ? false : true}>
+          {isFollow ? '팔로우' : '팔로잉'}
         </Button>
       </div>
     </>

--- a/src/components/UserProfile/UserProfileHeader/index.tsx
+++ b/src/components/UserProfile/UserProfileHeader/index.tsx
@@ -5,6 +5,8 @@ import { useRouter } from 'next/navigation';
 import Image from 'next/image';
 import { Button } from '@/components/common/Button/Button';
 import { useUserProfileQuery } from '@/hooks/apis/Auth/useUserProfileQuery';
+// import { useAssignFollowMutation } from '@/hooks/apis/Follow/useAssignFollowMutation';
+// import { useDeleteFollowMutation } from '@/hooks/apis/Follow/useDeleteFollowMutation';
 
 interface UserProfileHeader {
   userId: string;
@@ -14,9 +16,20 @@ export const UserProfileHeader = ({ userId }: UserProfileHeader) => {
   const router = useRouter();
 
   const { name, profilePic, isFollow } = useUserProfileQuery(Number(userId));
+  // const { mutate: assignFollow, isPending } = useAssignFollowMutation();
+  // const { mutate: deleteFollow } = useDeleteFollowMutation();
 
   const handleBack = () => {
     router.back();
+  };
+
+  const handleClickFollow = () => {
+    if (isFollow) {
+      console.log('dddd');
+    } else {
+      //assignFollow(Number(userId));
+      //deleteFollow(Number(userId));
+    }
   };
 
   return (
@@ -36,7 +49,12 @@ export const UserProfileHeader = ({ userId }: UserProfileHeader) => {
           ) : null}
           <span className="text-base-medium">{name}</span>
         </div>
-        <Button size="small" primary={isFollow ? false : true}>
+        <Button
+          size="small"
+          primary={isFollow ? false : true}
+          onClick={handleClickFollow}
+          // pending={isPending}
+        >
           {isFollow ? '팔로우' : '팔로잉'}
         </Button>
       </div>

--- a/src/constants/ApiEndpoints.ts
+++ b/src/constants/ApiEndpoints.ts
@@ -22,6 +22,7 @@ export const API_ENDPOINTS = {
     PASSWORD: '/api/v1/auths/password',
     FOLLOW_COUNT: '/api/v1/auths/mypage',
     WITHDRAWAL: '/api/v1/auths/withdrawl',
+    USER_PROFILE: (userId: number) => `/api/v1/auths/profile/${userId}`,
   },
 
   GOAL: {

--- a/src/constants/ApiEndpoints.ts
+++ b/src/constants/ApiEndpoints.ts
@@ -36,6 +36,8 @@ export const API_ENDPOINTS = {
   FOLLOW: {
     CREATE: (followerId: number) => `api/v1/follows/${followerId}`,
     DELETE: (followerId: number) => `api/v1/follows/${followerId}`,
+    ASSIGN_FOLLOW: (followId: number) => `/api/v1/follows/${followId}`,
+    DELETE_FOLLOW: (followId: number) => `/api/v1/follows/${followId}`,
     GET: `/api/v1/follows`,
   },
 

--- a/src/constants/QueryKeys.ts
+++ b/src/constants/QueryKeys.ts
@@ -12,4 +12,5 @@ export const QUERY_KEYS = {
   FOLLOW_COUNT: 'followCount',
   FOLLOWS: 'follows',
   TODOS_DETAIL: 'todosDetail',
+  USER_PROFILE: 'userProfile',
 };

--- a/src/hooks/apis/Auth/useUserProfileQuery.ts
+++ b/src/hooks/apis/Auth/useUserProfileQuery.ts
@@ -14,5 +14,10 @@ const userProfileOptions = (
 });
 
 export const useUserProfileQuery = (userId: number) => {
-  return useQuery(userProfileOptions(userId));
+  const { data, isLoading } = useQuery(userProfileOptions(userId));
+  const name = data?.data.name;
+  const profilePic = data?.data.profilePic;
+  const isFollow = data?.data.isFollow;
+  const completeResponses = data?.data.completeResponses ?? [];
+  return { name, profilePic, isFollow, completeResponses, isLoading };
 };

--- a/src/hooks/apis/Auth/useUserProfileQuery.ts
+++ b/src/hooks/apis/Auth/useUserProfileQuery.ts
@@ -1,0 +1,18 @@
+import { useQuery, UseQueryOptions } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+import { GET } from '@/apis/services/httpMethod';
+import { API_ENDPOINTS } from '@/constants/ApiEndpoints';
+import { QUERY_KEYS } from '@/constants/QueryKeys';
+import { UserProfileResponse } from '@/types/response';
+
+const userProfileOptions = (
+  userId: number,
+): UseQueryOptions<UserProfileResponse, AxiosError> => ({
+  queryKey: [QUERY_KEYS.USER_PROFILE, userId],
+  queryFn: () =>
+    GET<UserProfileResponse>(API_ENDPOINTS.AUTH.USER_PROFILE(userId)),
+});
+
+export const useUserProfileQuery = (userId: number) => {
+  return useQuery(userProfileOptions(userId));
+};

--- a/src/hooks/apis/Follow/useAssignFollowMutation.ts
+++ b/src/hooks/apis/Follow/useAssignFollowMutation.ts
@@ -1,0 +1,31 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { POST } from '@/apis/services/httpMethod';
+import { API_ENDPOINTS } from '@/constants/ApiEndpoints';
+import { AssignFollowResponse } from '@/types/response';
+import { notify } from '@/store/useToastStore';
+import { QUERY_KEYS } from '@/constants/QueryKeys';
+
+interface FollowId {
+  userId: number;
+}
+
+export const useAssignFollowMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (userId: number) =>
+      POST<AssignFollowResponse, FollowId>(
+        API_ENDPOINTS.FOLLOW.ASSIGN_FOLLOW(userId),
+      ),
+    onSuccess: (data) => {
+      notify('success', '팔로우 등록', 3000);
+      queryClient.invalidateQueries({
+        queryKey: [QUERY_KEYS.USER_PROFILE, data.data.followId],
+      });
+    },
+    onError: (error) => {
+      console.error(error.message);
+      notify('error', '팔로우 등록 실패', 3000);
+    },
+  });
+};

--- a/src/hooks/apis/Follow/useAssignFollowMutation.ts
+++ b/src/hooks/apis/Follow/useAssignFollowMutation.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { POST } from '@/apis/services/httpMethod';
 import { API_ENDPOINTS } from '@/constants/ApiEndpoints';
-import { AssignFollowResponse } from '@/types/response';
+import { AssignFollowResponse, UserProfileResponse } from '@/types/response';
 import { notify } from '@/store/useToastStore';
 import { QUERY_KEYS } from '@/constants/QueryKeys';
 
@@ -17,13 +17,40 @@ export const useAssignFollowMutation = () => {
       POST<AssignFollowResponse, FollowId>(
         API_ENDPOINTS.FOLLOW.ASSIGN_FOLLOW(userId),
       ),
-    onSuccess: (data) => {
-      notify('success', '팔로우 등록', 3000);
+    onMutate: async (userId) => {
+      const previousData = queryClient.getQueriesData<UserProfileResponse>({
+        queryKey: [QUERY_KEYS.USER_PROFILE, userId],
+      });
+
+      await queryClient.cancelQueries({
+        queryKey: [QUERY_KEYS.USER_PROFILE, userId],
+      });
+
+      queryClient.setQueryData(
+        [QUERY_KEYS.USER_PROFILE, userId],
+        (oldData: UserProfileResponse) => ({
+          ...oldData,
+          data: {
+            ...oldData.data,
+            isFollow: true,
+          },
+        }),
+      );
+      return { previousData };
+    },
+    onSettled: (userId) => {
       queryClient.invalidateQueries({
-        queryKey: [QUERY_KEYS.USER_PROFILE, data.data.followId],
+        queryKey: [QUERY_KEYS.USER_PROFILE, userId],
       });
     },
-    onError: (error) => {
+    onSuccess: () => {
+      notify('success', '팔로우 등록', 3000);
+    },
+    onError: (error, userId, context) => {
+      queryClient.setQueryData(
+        [QUERY_KEYS.USER_PROFILE, userId],
+        context?.previousData,
+      );
       console.error(error.message);
       notify('error', '팔로우 등록 실패', 3000);
     },

--- a/src/hooks/apis/Follow/useDeleteFollowMutation.ts
+++ b/src/hooks/apis/Follow/useDeleteFollowMutation.ts
@@ -1,0 +1,31 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { POST } from '@/apis/services/httpMethod';
+import { API_ENDPOINTS } from '@/constants/ApiEndpoints';
+import { DeleteFollowResponse } from '@/types/response';
+import { notify } from '@/store/useToastStore';
+import { QUERY_KEYS } from '@/constants/QueryKeys';
+
+interface FollowId {
+  userId: number;
+}
+
+export const useDeleteFollowMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (userId: number) =>
+      POST<DeleteFollowResponse, FollowId>(
+        API_ENDPOINTS.FOLLOW.DELETE_FOLLOW(userId),
+      ),
+    onSuccess: (data) => {
+      notify('success', '팔로우 취소', 3000);
+      queryClient.invalidateQueries({
+        queryKey: [QUERY_KEYS.USER_PROFILE, data.data.followerId],
+      });
+    },
+    onError: (error) => {
+      console.error(error.message);
+      notify('error', '팔로우 취소 실패', 3000);
+    },
+  });
+};

--- a/src/hooks/apis/Follow/useDeleteFollowMutation.ts
+++ b/src/hooks/apis/Follow/useDeleteFollowMutation.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { POST } from '@/apis/services/httpMethod';
 import { API_ENDPOINTS } from '@/constants/ApiEndpoints';
-import { DeleteFollowResponse } from '@/types/response';
+import { DeleteFollowResponse, UserProfileResponse } from '@/types/response';
 import { notify } from '@/store/useToastStore';
 import { QUERY_KEYS } from '@/constants/QueryKeys';
 
@@ -17,13 +17,41 @@ export const useDeleteFollowMutation = () => {
       POST<DeleteFollowResponse, FollowId>(
         API_ENDPOINTS.FOLLOW.DELETE_FOLLOW(userId),
       ),
-    onSuccess: (data) => {
-      notify('success', '팔로우 취소', 3000);
+    onMutate: async (userId) => {
+      const previousData = queryClient.getQueriesData<UserProfileResponse>({
+        queryKey: [QUERY_KEYS.USER_PROFILE, userId],
+      });
+
+      await queryClient.cancelQueries({
+        queryKey: [QUERY_KEYS.USER_PROFILE, userId],
+      });
+
+      queryClient.setQueryData(
+        [QUERY_KEYS.USER_PROFILE, userId],
+        (oldData: UserProfileResponse) => ({
+          ...oldData,
+          data: {
+            ...oldData.data,
+            isFollow: false,
+          },
+        }),
+      );
+      return { previousData };
+    },
+
+    onSettled: (userId) => {
       queryClient.invalidateQueries({
-        queryKey: [QUERY_KEYS.USER_PROFILE, data.data.followerId],
+        queryKey: [QUERY_KEYS.USER_PROFILE, userId],
       });
     },
-    onError: (error) => {
+    onSuccess: () => {
+      notify('success', '팔로우 취소', 3000);
+    },
+    onError: (error, userId, context) => {
+      queryClient.setQueryData(
+        [QUERY_KEYS.USER_PROFILE, userId],
+        context?.previousData,
+      );
       console.error(error.message);
       notify('error', '팔로우 취소 실패', 3000);
     },

--- a/src/types/data.ts
+++ b/src/types/data.ts
@@ -48,3 +48,9 @@ export interface ContentTypes {
 export interface TodoDetailTypes extends TodoTypes {
   todoPicName: string;
 }
+export interface UserProfileTypes {
+  name: string;
+  profilePic: string;
+  isFollow: boolean;
+  completeResponses: CompleteTypes[];
+}

--- a/src/types/response.ts
+++ b/src/types/response.ts
@@ -1,4 +1,4 @@
-import { TodoDetailTypes } from './data';
+import { TodoDetailTypes, UserProfileTypes } from './data';
 
 export interface BaseResponse {
   statusCode: number;
@@ -18,4 +18,8 @@ export interface WithdrawalResponse extends BaseResponse {
 
 export interface TodoDetailResponse extends BaseResponse {
   data: TodoDetailTypes;
+}
+
+export interface UserProfileResponse extends BaseResponse {
+  data: UserProfileTypes;
 }

--- a/src/types/response.ts
+++ b/src/types/response.ts
@@ -23,3 +23,16 @@ export interface TodoDetailResponse extends BaseResponse {
 export interface UserProfileResponse extends BaseResponse {
   data: UserProfileTypes;
 }
+
+export interface AssignFollowResponse extends BaseResponse {
+  data: {
+    followId: number;
+  };
+}
+
+export interface DeleteFollowResponse extends BaseResponse {
+  data: {
+    followerId: number;
+    followeeId: number;
+  };
+}


### PR DESCRIPTION
# 📄 타인 프로필 페이지 (데이터 불러오기, 팔로우 기능)

## 📝 변경 사항 요약
- 타인 프로필 데이터 불러오기
- 팔로우 기능

## 📌 관련 이슈
- 이슈 번호: #160 

## 🔍 변경 사항 상세 설명
타인 프로필 데이터 불러오기
- 타인 프로필 데이터의 쿼리를 타인 userId를 이용하여 특정하였음.

팔로우 기능
- 낙관적 업데이트를 이용하여 사용자의 경험을 개선함.

## ✅ 확인 사항
- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 관련 테스트를 작성하고 모두 통과했는지 확인했습니다.
- [x] 코드 스타일 가이드에 맞게 작성했습니다.

## 📸 스크린샷 (선택 사항)
![타인 프로필 낙관적 업데이트 Gif](https://github.com/user-attachments/assets/77984a69-112d-4299-b60e-62ab38969414)


## 기타 참고 사항
추후에 불필요한 중복된 api들은 상의한 다음 제거하도록 하겠습니다.
