### PR TITLE
[Fix] 에러 처리 중복 현상 제거

### DIFF
--- a/src/apis/services/httpMethod.ts
+++ b/src/apis/services/httpMethod.ts
@@ -1,5 +1,6 @@
+import { AxiosError } from 'axios';
+
 import axiosInstance, { setAuthToken } from '@/lib/axiosInstance';
-import { handleHttpError } from '@/utils/handleHttpError';
 
 type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE';
 
@@ -29,8 +30,14 @@ async function request<T>({
 
     return response.data;
   } catch (error) {
-    handleHttpError(error);
-    throw error;
+    if (!(error instanceof AxiosError)) {
+      throw new Error('오류가 발생했습니다.');
+    }
+
+    const status = error.response?.status;
+    const message = error.response?.data.message || error.message;
+
+    throw new Error(JSON.stringify({ status, message }));
   }
 }
 


### PR DESCRIPTION
# 📄 에러 처리 중복 현상 제거

## 📝 변경 사항 요약
- 에러 처리 중복 제거

## 📌 관련 이슈
- 이슈 번호: #205

## 🔍 변경 사항 상세 설명
이전에 수정한 방식에서 `QueryClient`에 공통으로 `get` 요청에 대한 에러 처리를 해두었고 공통 `api` 함수에서도 공통으로 에러 처리를 하게 되어서 이를 수정

기존에는 `mutation` 에러가 발생하면 공통 에러처리, `useMutation`에서 `onError`로 에러처리가 2번 중복되었다.

`get` 요청에 대한 에러 처리는 기존처럼 공통으로 두고 공통 `api` 에서 처리하지 않고 `status`, `message`만 넘겨주어 `useMutation`을 사용한 hook에서 개별로 처리할 수 있도록 하였다.


## ✅ 확인 사항
- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 관련 테스트를 작성하고 모두 통과했는지 확인했습니다.
- [x] 코드 스타일 가이드에 맞게 작성했습니다.
